### PR TITLE
run-publish's PRODUCTS param renamed to PRODUCT

### DIFF
--- a/pipelines/build_publish_tag.groovy
+++ b/pipelines/build_publish_tag.groovy
@@ -61,7 +61,7 @@ try {
         string(name: 'EUPSPKG_SOURCE', value: 'git'),
         string(name: 'BUILD_ID', value: bx),
         string(name: 'TAG', value: EUPS_TAG),
-        string(name: 'PRODUCTS', value: PRODUCT)
+        string(name: 'PRODUCT', value: PRODUCT)
       ]
   }
 
@@ -71,7 +71,7 @@ try {
         string(name: 'EUPSPKG_SOURCE', value: 'git'),
         string(name: 'BUILD_ID', value: bx),
         string(name: 'TAG', value: 'w_latest'),
-        string(name: 'PRODUCTS', value: PRODUCT)
+        string(name: 'PRODUCT', value: PRODUCT)
       ]
   }
 


### PR DESCRIPTION
The job parameter renaming was accidental as part of DM-7898.  The
breakage of `run-publish`'s shell step has already been fixed on master.