### PR TITLE
install sqre-codekit via pip

### DIFF
--- a/jobs/tag_git_repos.groovy
+++ b/jobs/tag_git_repos.groovy
@@ -63,7 +63,7 @@ def j = job('release/tag-git-repos') {
       virtualenv venv
       . venv/bin/activate
       pip install -r requirements.txt
-      python setup.py install
+      pip install .
 
       # do not echo GH token to console log
       set +x


### PR DESCRIPTION
To seems that `python setup.py install` and `pip install .` are handling
recursive dependencies differently.

This commit:

https://github.com/lsst-sqre/sqre-codekit/commit/2acb2d612c25e0098a027a8c0845deb3e46626ba

seems to have broken `setup.py` while `pip install [-e] .` succeeds.  We
are changing the jenkins installation method rather than downgrading the
python module.