### PR TITLE
remove w_latest tagging from release/build-publish-tag

### DIFF
--- a/pipelines/build_publish_tag.groovy
+++ b/pipelines/build_publish_tag.groovy
@@ -65,16 +65,6 @@ try {
       ]
   }
 
-  stage('eups publish [w_latest]') {
-    build job: 'run-publish',
-      parameters: [
-        string(name: 'EUPSPKG_SOURCE', value: 'git'),
-        string(name: 'BUILD_ID', value: bx),
-        string(name: 'TAG', value: 'w_latest'),
-        string(name: 'PRODUCT', value: PRODUCT)
-      ]
-  }
-
   stage('git tag') {
     build job: 'release/tag-git-repos',
       parameters: [


### PR DESCRIPTION
Migrated to release/weekly-release; this is currently a duplicate
operation when run from weekly-release.