### PR TITLE
DM-8711: validate_drp job - update post-qa to v1.2.2

### DIFF
--- a/jobs/validate_drp.groovy
+++ b/jobs/validate_drp.groovy
@@ -159,7 +159,8 @@ def j = matrixJob('validate_drp') {
 
       virtualenv venv
       . venv/bin/activate
-      pip install post-qa==1.1.0
+      pip install functools32
+      pip install post-qa==1.2.2
 
       post-qa --lsstsw "$LSSTSW" --qa-json "$OUTPUT" --api-url "$SQUASH_URL/jobs/"  --api-user "$SQUASH_USER" --api-password "$SQUASH_PASS"
       '''.replaceFirst("\n","").stripIndent()


### PR DESCRIPTION
Required by validate_base -based validate_drp.

Also manually installing functools32. This is needed by jsonschema when
running under Python 2.7, but somehow it isn't being installed normally.

This is no longer needed if the job is changed to run in Python 3.