### PR TITLE
lsst-dev[-old] has been retired

### DIFF
--- a/jobs/run_publish.groovy
+++ b/jobs/run_publish.groovy
@@ -15,6 +15,10 @@ def j = job('release/run-publish') {
   concurrentBuild(false)
   customWorkspace('/home/lsstsw/jenkins/release')
 
+  environmentVariables {
+    env('EUPS_PKGROOT', '/lsst/distserver/production')
+  }
+
   wrappers {
     colorizeOutput('gnome-terminal')
   }

--- a/jobs/run_publish.groovy
+++ b/jobs/run_publish.groovy
@@ -1,5 +1,7 @@
 import util.Common
 
+// note that this job *will not work* unless run-rebuild has been executed at
+// least once in order to initialize the env.
 def j = job('release/run-publish') {
   parameters {
     choiceParam('EUPSPKG_SOURCE', ['git', 'package'])
@@ -10,6 +12,7 @@ def j = job('release/run-publish') {
 
   label('lsst-dev')
   concurrentBuild(false)
+  customWorkspace('/home/lsstsw/jenkins/release')
 
   wrappers {
     colorizeOutput('gnome-terminal')
@@ -30,7 +33,7 @@ def j = job('release/run-publish') {
       export EUPSPKG_SOURCE="$EUPSPKG_SOURCE"
 
       # setup.sh will unset $PRODUCTS
-      source "${HOME}/bin/setup.sh"
+      source ./lsstsw/bin/setup.sh
 
       publish "${ARGS[@]}"
       '''.replaceFirst("\n","").stripIndent()

--- a/jobs/run_publish.groovy
+++ b/jobs/run_publish.groovy
@@ -1,4 +1,5 @@
 import util.Common
+Common.makeFolders(this)
 
 // note that this job *will not work* unless run-rebuild has been executed at
 // least once in order to initialize the env.

--- a/jobs/run_rebuild.groovy
+++ b/jobs/run_rebuild.groovy
@@ -17,7 +17,7 @@ def j = job('release/run-rebuild') {
 
   label('lsst-dev')
   concurrentBuild(false)
-  customWorkspace('/home/lsstsw')
+  customWorkspace('/home/lsstsw/jenkins/release')
 
   multiscm {
     git {
@@ -58,8 +58,6 @@ def j = job('release/run-rebuild') {
         export REPOSFILE="${WORKSPACE}/REPOS"
       fi
 
-      export LSSTSW="$WORKSPACE"
-
       ./buildbot-scripts/jenkins_wrapper.sh
 
       # handled by the postbuild on failure script if there is an error
@@ -91,7 +89,10 @@ def j = job('release/run-rebuild') {
       }
     }
 
-    archiveArtifacts('build/manifest.txt')
+    archiveArtifacts {
+      fingerprint()
+      pattern('lsstsw/build/manifest.txt')
+    }
   }
 }
 

--- a/jobs/run_rebuild.groovy
+++ b/jobs/run_rebuild.groovy
@@ -1,4 +1,5 @@
 import util.Common
+Common.makeFolders(this)
 
 def j = job('release/run-rebuild') {
   parameters {
@@ -26,6 +27,7 @@ def j = job('release/run-rebuild') {
       }
       branch('*/master')
       extensions {
+        relativeTargetDirectory('lsstsw')
         cloneOptions { shallow() }
       }
     }

--- a/jobs/run_rebuild.groovy
+++ b/jobs/run_rebuild.groovy
@@ -16,6 +16,10 @@ def j = job('release/run-rebuild') {
     }
   }
 
+  environmentVariables {
+    env('EUPS_PKGROOT', '/lsst/distserver/production')
+  }
+
   label('lsst-dev')
   concurrentBuild(false)
   customWorkspace('/home/lsstsw/jenkins/release')

--- a/pipelines/build_publish_tag.groovy
+++ b/pipelines/build_publish_tag.groovy
@@ -42,13 +42,15 @@ try {
 
   stage('parse bNNNN') {
     node {
+      manifest_artifact = 'lsstsw/build/manifest.txt'
+
       step ([$class: 'CopyArtifact',
             projectName: buildJob,
-            filter: 'build/manifest.txt',
+            filter: manifest_artifact,
             selector: [$class: 'SpecificBuildSelector', buildNumber: rebuildId]
             ]);
 
-      def manifest = readFile 'build/manifest.txt'
+      def manifest = readFile manifest_artifact
       bx = bxxxx(manifest)
 
       echo "parsed bxxxx: ${bx}"


### PR DESCRIPTION
Post retirement of lsst-dev[-old], we are redoing the path layout of the `lsstsw` account.  All jenkins related files, including the `lsst/lsstsw` checkout used by jenkins, are being relocated to be under the path `~lsstsw/jenkins/`.