### PR TITLE
specify full path of job to invoke

### DIFF
--- a/pipelines/build_publish.groovy
+++ b/pipelines/build_publish.groovy
@@ -22,7 +22,8 @@ try {
 
   def bx = null
   def rebuildId = null
-  def buildJob = 'run-rebuild'
+  def buildJob = 'release/run-rebuild'
+  def publishJob = 'release/run-publish'
 
   stage('build') {
     def result = build job: buildJob,
@@ -54,7 +55,7 @@ try {
   }
 
   stage('eups publish [tag]') {
-    build job: 'run-publish',
+    build job: publishJob,
       parameters: [
         string(name: 'EUPSPKG_SOURCE', value: 'git'),
         string(name: 'BUILD_ID', value: bx),

--- a/pipelines/build_publish_tag.groovy
+++ b/pipelines/build_publish_tag.groovy
@@ -26,7 +26,8 @@ try {
 
   def bx = null
   def rebuildId = null
-  def buildJob = 'run-rebuild'
+  def buildJob = 'release/run-rebuild'
+  def publishJob = 'release/run-publish'
 
   stage('build') {
     def result = build job: buildJob,
@@ -58,7 +59,7 @@ try {
   }
 
   stage('eups publish [tag]') {
-    build job: 'run-publish',
+    build job: publishJob,
       parameters: [
         string(name: 'EUPSPKG_SOURCE', value: 'git'),
         string(name: 'BUILD_ID', value: bx),

--- a/pipelines/qserv/release/tag_latest+dev.groovy
+++ b/pipelines/qserv/release/tag_latest+dev.groovy
@@ -19,8 +19,8 @@ try {
 
   def bx = null
   def rebuildId = null
-  def buildJob = 'run-rebuild'
-  def publishJob = 'run-publish'
+  def buildJob = 'release/run-rebuild'
+  def publishJob = 'release/run-publish'
 
   stage('build') {
     def result = build job: buildJob,

--- a/pipelines/qserv/release/tag_qserv_dev.groovy
+++ b/pipelines/qserv/release/tag_qserv_dev.groovy
@@ -19,8 +19,8 @@ try {
 
   def bx = null
   def rebuildId = null
-  def buildJob = 'run-rebuild'
-  def publishJob = 'run-publish'
+  def buildJob = 'release/run-rebuild'
+  def publishJob = 'release/run-publish'
 
   stage('build') {
     def result = build job: buildJob,

--- a/pipelines/qserv/release/tag_qserv_latest.groovy
+++ b/pipelines/qserv/release/tag_qserv_latest.groovy
@@ -19,8 +19,8 @@ try {
 
   def bx = null
   def rebuildId = null
-  def buildJob = 'run-rebuild'
-  def publishJob = 'run-publish'
+  def buildJob = 'release/run-rebuild'
+  def publishJob = 'release/run-publish'
 
   stage('build') {
     def result = build job: buildJob,


### PR DESCRIPTION
Oddly, the short name of the job (job name not including the folder) has
been working in the past but this is all of a sudden failing:

    ERROR: No parameterized job named run-rebuild found