### PR TITLE
add ssh-agent github-jenkins-versiondb run-rebuild

### DIFF
--- a/jobs/run_rebuild.groovy
+++ b/jobs/run_rebuild.groovy
@@ -53,6 +53,7 @@ def j = job('release/run-rebuild') {
 
   wrappers {
     colorizeOutput('gnome-terminal')
+    sshAgent('github-jenkins-versiondb')
   }
 
   steps {


### PR DESCRIPTION
Needed in order to push updates to `lsst/versiondb`.  In the past, this
has been handled by manually setting up ssh keys in the account
`lsst/lsstsw` has been running under.  This is problematic as these
credentials are available to any clone of `lsst/lsstsw` running under that
account, not just the "canonical" instance.  It also complicates
management of CI build slaves.