### PR TITLE
disable validate_drp decam dataset

### DIFF
--- a/jobs/validate_drp.groovy
+++ b/jobs/validate_drp.groovy
@@ -41,7 +41,7 @@ def j = matrixJob('validate_drp') {
 
   axes {
     label('label', 'centos-7')
-    text('dataset', 'cfht', 'decam')
+    text('dataset', 'cfht')
     text('python', 'py2')
   }
 


### PR DESCRIPTION
Failing on the production jenkins instance and the cause is currently
unknown.