### PR TITLE
set NUMPROC=1 for cfht/decam datasets

### DIFF
--- a/jobs/validate_drp.groovy
+++ b/jobs/validate_drp.groovy
@@ -238,6 +238,11 @@ def j = matrixJob('validate_drp') {
       MEM_PER_CORE=2.0
       export NUMPROC=$(($(target_cores $MEM_PER_CORE) + 1))
 
+      # XXX testing cfht/decam dataset timeouts
+      if [[ "$dataset" != "hsc" ]]; then
+        export NUMPROC=1
+      fi
+
       set +e
       "$RUN" --noplot
       run_status=$?


### PR DESCRIPTION
These datasets are appear to be hitting the 9999s task timeout after the
pybind11 merge.  The problem is non-obvious so we are punting for the
time being to get these datasets working again in production.

See: https://jira.lsstcorp.org/browse/DM-9746