### PR TITLE
remove lsst_py3 job

### DIFF
--- a/jobs/stack_wrappers.groovy
+++ b/jobs/stack_wrappers.groovy
@@ -21,11 +21,6 @@ import util.StackOsMatrix
     skip_demo: true,
   ],
   [
-    product: 'lsst_py3',
-    skip_demo: true,
-    python: 'py3',
-  ],
-  [
     product: 'ci_hsc',
     skip_demo: true,
   ],


### PR DESCRIPTION
No longer needed as pipelines py3 porting effort is complete.