### PR TITLE
discard all but the last 1000 stack-os-matrix builds

### DIFF
--- a/jobs/stack_os_matrix.groovy
+++ b/jobs/stack_os_matrix.groovy
@@ -121,6 +121,9 @@ def j = matrixJob('stack-os-matrix') {
       fingerprint()
       pattern('lsstsw/build/manifest.txt')
     }
+    publishBuild {
+      discardOldBuilds(-1, 1000, -1, -1)
+    }
   }
 }
 


### PR DESCRIPTION
This is a test to see if this improves per user "builds" page load
times.