### PR TITLE
disable osx tarball builds

### DIFF
--- a/pipelines/release/tarball.groovy
+++ b/pipelines/release/tarball.groovy
@@ -53,11 +53,14 @@ try {
         }
       }
 
+      // disable osx builds while osx nodes are inaccessible
+      /*
       platform['osx-10.11'] = {
         retry(retries) {
           osxTarballs('10.11', '10.9', 'clang-800.0.42.1', py)
         }
       }
+      */
 
       parallel platform
     }


### PR DESCRIPTION
Due to OSX nodes becoming unavailable.