### PR TITLE
fix update-cmirror job on disk file ownership

### DIFF
--- a/pipelines/lib/util.groovy
+++ b/pipelines/lib/util.groovy
@@ -67,4 +67,29 @@ def void wrapContainer(String imageName, String tag) {
   }
 }
 
+/**
+ * Join multiple String args togther with '/'s to resemble a filesystem path.
+ */
+// The groovy String#join method is not working under the security sandbox
+// https://issues.jenkins-ci.org/browse/JENKINS-43484
+@NonCPS
+def String joinPath(String ... parts) {
+  String text = null
+
+  def n = parts.size()
+  parts.eachWithIndex { x, i ->
+    if (text == null) {
+      text = x
+    } else {
+      text += x
+    }
+
+    if (i < (n - 1)) {
+      text += '/'
+    }
+  }
+
+  return text
+}
+
 return this;

--- a/pipelines/lib/util.groovy
+++ b/pipelines/lib/util.groovy
@@ -1,4 +1,14 @@
 /**
+ * Thin wrapper around {@code sh} step that strips leading whitspace and
+ * enables ANSI color codes.
+ */
+def void shColor(script) {
+  wrap([$class: 'AnsiColorBuildWrapper']) {
+    sh dedent(script)
+  }
+}
+
+/**
  * Create a thin "wrapper" container around {@code imageName} to map uid/gid of
  * the user invoking docker into the container.
  *

--- a/pipelines/lib/util.groovy
+++ b/pipelines/lib/util.groovy
@@ -1,0 +1,49 @@
+/**
+ * Create a thin "wrapper" container around {@code imageName} to map uid/gid of
+ * the user invoking docker into the container.
+ *
+ * @param imageName docker image slug
+ * @param tag name of tag to apply to generated image
+ */
+def void wrapContainer(String imageName, String tag) {
+  def buildDir = 'docker'
+  def config = dedent("""
+    FROM    ${imageName}
+
+    ARG     USER
+    ARG     UID
+    ARG     GROUP
+    ARG     GID
+    ARG     HOME
+
+    USER    root
+    RUN     groupadd -g \$GID \$GROUP
+    RUN     useradd -d \$HOME -g \$GROUP -u \$UID \$USER
+
+    USER    \$USER
+    WORKDIR \$HOME
+  """)
+
+  // docker insists on recusrively checking file access under its execution
+  // path -- so run it from a dedicated dir
+  dir(buildDir) {
+    writeFile(file: 'Dockerfile', text: config)
+
+    shColor """
+      set -e
+      set -x
+
+      docker build -t "${tag}" \
+          --build-arg USER="\$(id -un)" \
+          --build-arg UID="\$(id -u)" \
+          --build-arg GROUP="\$(id -gn)" \
+          --build-arg GID="\$(id -g)" \
+          --build-arg HOME="\$HOME" \
+          .
+    """
+
+    deleteDir()
+  }
+}
+
+return this;

--- a/pipelines/lib/util.groovy
+++ b/pipelines/lib/util.groovy
@@ -1,4 +1,15 @@
 /**
+ * Remove leading whitespace from a multi-line String (probably a shellscript).
+ */
+@NonCPS
+def String dedent(String text) {
+  if (text == null) {
+    return null
+  }
+  text.replaceFirst("\n","").stripIndent()
+}
+
+/**
  * Thin wrapper around {@code sh} step that strips leading whitspace and
  * enables ANSI color codes.
  */

--- a/pipelines/release/run_publish.groovy
+++ b/pipelines/release/run_publish.groovy
@@ -9,6 +9,7 @@ node('jenkins-master') {
       userRemoteConfigs: scm.getUserRemoteConfigs()
     ])
     notify = load 'pipelines/lib/notify.groovy'
+    util = load 'pipelines/lib/util.groovy'
   }
 }
 
@@ -45,7 +46,7 @@ try {
           variable: 'CMIRROR_S3_BUCKET'
         ]]) {
           withEnv(env) {
-            shColor '''
+            util.shColor '''
               #!/bin/bash -e
 
               # ensure that we are using the lsstsw clone relative to the workspace
@@ -68,7 +69,7 @@ try {
               source ./lsstsw/bin/setup.sh
 
               publish "${ARGS[@]}"
-            '''.replaceFirst("\n","").stripIndent()
+            '''
           }
         }// withCredentials([[
       } // stage('publish')
@@ -91,7 +92,7 @@ try {
           ]
 
           withEnv(env) {
-            shColor '''
+            util.shColor '''
               #!/bin/bash -e
 
               # setup python env
@@ -99,7 +100,7 @@ try {
               pip install awscli
 
               aws s3 sync "$EUPS_PKGROOT"/ s3://$EUPS_S3_BUCKET/stack/src/
-            '''.replaceFirst("\n","").stripIndent()
+            '''
           }
         }
       } // stage('push packages')
@@ -124,11 +125,5 @@ try {
       break
     default:
       notify.failure()
-  }
-}
-
-def shColor(script) {
-  wrap([$class: 'AnsiColorBuildWrapper']) {
-    sh script
   }
 }

--- a/pipelines/release/run_rebuild.groovy
+++ b/pipelines/release/run_rebuild.groovy
@@ -9,6 +9,7 @@ node('jenkins-master') {
       userRemoteConfigs: scm.getUserRemoteConfigs()
     ])
     notify = load 'pipelines/lib/notify.groovy'
+    util = load 'pipelines/lib/util.groovy'
   }
 }
 
@@ -47,7 +48,7 @@ try {
           ]]) {
             withEnv(env) {
               sshagent (credentials: ['github-jenkins-versiondb']) {
-                shColor '''
+                util.shColor '''
                   #!/bin/bash -e
 
                   # ensure that we are using the lsstsw clone relative to the workspace
@@ -65,13 +66,13 @@ try {
 
                   # handled by the postbuild on failure script if there is an error
                   rm -rf "${WORKSPACE}/REPOS"
-                '''.replaceFirst("\n","").stripIndent()
+                '''
               }
             }
           } // withCredentials([[
         } finally {
           withEnv(["WORKSPACE=${pwd()}"]) {
-            shColor '''
+            util.shColor '''
               if hash lsof 2>/dev/null; then
                 Z=$(lsof -d 200 -t)
                 if [[ ! -z $Z ]]; then
@@ -83,7 +84,7 @@ try {
 
               rm -rf "${WORKSPACE}/lsstsw/stack/.lockDir"
               rm -rf "${WORKSPACE}/REPOS"
-            '''.stripIndent()
+            '''
           }
 
           archiveArtifacts([
@@ -106,7 +107,7 @@ try {
           variable: 'DOXYGEN_S3_BUCKET'
         ]]) {
           withEnv(["WORKSPACE=${pwd()}"]) {
-            shColor '''
+            util.shColor '''
               #!/bin/bash -e
 
               if [[ $SKIP_DOCS == "true" ]]; then
@@ -121,7 +122,7 @@ try {
               . ./buildbot-scripts/settings.cfg.sh
 
               aws s3 sync "$DOC_PUSH_PATH"/ s3://$DOXYGEN_S3_BUCKET/stack/doxygen/
-            '''.replaceFirst("\n","").stripIndent()
+            '''
           }
         }
       } // stage('push docs')
@@ -146,11 +147,5 @@ try {
       break
     default:
       notify.failure()
-  }
-}
-
-def shColor(script) {
-  wrap([$class: 'AnsiColorBuildWrapper']) {
-    sh script
   }
 }

--- a/pipelines/release/tarball.groovy
+++ b/pipelines/release/tarball.groovy
@@ -199,7 +199,7 @@ def void linuxBuild(String imageName, String compiler, MinicondaEnv menv) {
     def shName = "${shPath}/${shBasename}"
     def localImageName = "${imageName}-local"
 
-    shColor 'mkdir -p distrib build scripts'
+    util.shColor 'mkdir -p distrib build scripts'
 
     prepareBuild(
       params.PRODUCT,
@@ -214,7 +214,7 @@ def void linuxBuild(String imageName, String compiler, MinicondaEnv menv) {
     util.wrapContainer(imageName, localImageName)
 
     withEnv(["RUN=/scripts/${shBasename}", "IMAGE=${localImageName}"]) {
-      shColor '''
+      util.shColor '''
         set -e
 
         docker run \
@@ -246,7 +246,7 @@ def void osxBuild(
   try {
     def shName = "${pwd()}/scripts/run.sh"
 
-    shColor 'mkdir -p distrib build scripts'
+    util.shColor 'mkdir -p distrib build scripts'
 
     prepareBuild(
       params.PRODUCT,
@@ -259,7 +259,7 @@ def void osxBuild(
     )
 
     dir('build') {
-      shColor """
+      util.shColor """
         set -e
 
         "${shName}"
@@ -285,7 +285,7 @@ def void linuxSmoke(String imageName, String compiler, MinicondaEnv menv) {
     deleteDir()
   }
 
-  shColor 'mkdir -p smoke'
+  util.shColor 'mkdir -p smoke'
 
   prepareSmoke(
     params.PRODUCT,
@@ -312,7 +312,7 @@ def void linuxSmoke(String imageName, String compiler, MinicondaEnv menv) {
     "IMAGE=${localImageName}",
     "RUN_DEMO=${params.RUN_DEMO}",
   ]) {
-    shColor '''
+    util.shColor '''
       set -e
 
       docker run \
@@ -371,7 +371,7 @@ def void osxSmoke(
       "RUN_DEMO=${params.RUN_DEMO}",
       "FIX_SHEBANGS=true",
     ]) {
-      shColor """
+      util.shColor """
         set -e
 
         ${shName}
@@ -402,7 +402,7 @@ def void prepareBuild(
   )
 
   writeFile(file: shName, text: script)
-  shColor "chmod a+x ${shName}"
+  util.shColor "chmod a+x ${shName}"
 }
 
 /**
@@ -429,7 +429,7 @@ def void prepareSmoke(
   )
 
   writeFile(file: shName, text: script)
-  shColor "chmod a+x ${shName}"
+  util.shColor "chmod a+x ${shName}"
 }
 
 /**
@@ -439,7 +439,7 @@ def void prepareSmoke(
 def void s3Push(String ... parts) {
   def path = joinPath(parts)
 
-  shColor '''
+  util.shColor '''
     set -e
     # do not assume virtualenv is present
     pip install virtualenv
@@ -454,7 +454,7 @@ def void s3Push(String ... parts) {
     usernameVariable: 'AWS_ACCESS_KEY_ID',
     passwordVariable: 'AWS_SECRET_ACCESS_KEY'
   ]]) {
-    shColor """
+    util.shColor """
       set -e
       . venv/bin/activate
       aws s3 sync --only-show-errors ./distrib/ s3://\$EUPS_S3_BUCKET/stack/${path}
@@ -466,17 +466,7 @@ def void s3Push(String ... parts) {
  * Cleanup after a build attempt.
  */
 def void cleanup() {
-  shColor 'rm -rf "./build/.lockDir"'
-}
-
-/**
- * Thin wrapper around {@code sh} step that strips leading whitspace and
- * enables ANSI color codes.
- */
-def void shColor(script) {
-  wrap([$class: 'AnsiColorBuildWrapper']) {
-    sh dedent(script)
-  }
+  util.shColor 'rm -rf "./build/.lockDir"'
 }
 
 /**

--- a/pipelines/release/tarball.groovy
+++ b/pipelines/release/tarball.groovy
@@ -103,7 +103,7 @@ def void linuxTarballs(
   MinicondaEnv menv
 ) {
   def String slug = menv.slug()
-  def envId = joinPath('redhat', platform, compiler, slug)
+  def envId = util.joinPath('redhat', platform, compiler, slug)
 
   node('docker') {
     if (params.WIPEOUT) {
@@ -154,7 +154,7 @@ def void osxTarballs(
   MinicondaEnv menv
 ) {
   def String slug = menv.slug()
-  def envId = joinPath('osx', macosx_deployment_target, compiler, slug)
+  def envId = util.joinPath('osx', macosx_deployment_target, compiler, slug)
 
   node("osx-${platform}") {
     if (params.WIPEOUT) {
@@ -437,7 +437,7 @@ def void prepareSmoke(
  * joining the {@code parts} parameters.
  */
 def void s3Push(String ... parts) {
-  def path = joinPath(parts)
+  def path = util.joinPath(parts)
 
   util.shColor '''
     set -e
@@ -676,29 +676,4 @@ class MinicondaEnv implements Serializable {
   String slug() {
     "miniconda${pythonVersion}-${minicondaVersion}-${lsstswRef}"
   }
-}
-
-/**
- * Join multiple String args togther with '/'s to resemble a filesystem path.
- */
-// The groovy String#join method is not working under the security sandbox
-// https://issues.jenkins-ci.org/browse/JENKINS-43484
-@NonCPS
-def String joinPath(String ... parts) {
-  String text = null
-
-  def n = parts.size()
-  parts.eachWithIndex { x, i ->
-    if (text == null) {
-      text = x
-    } else {
-      text += x
-    }
-
-    if (i < (n - 1)) {
-      text += '/'
-    }
-  }
-
-  return text
 }

--- a/pipelines/release/tarball.groovy
+++ b/pipelines/release/tarball.groovy
@@ -16,6 +16,7 @@ node {
       userRemoteConfigs: scm.getUserRemoteConfigs()
     ])
     notify = load 'pipelines/lib/notify.groovy'
+    util = load 'pipelines/lib/util.groovy'
   }
 }
 
@@ -210,7 +211,7 @@ def void linuxBuild(String imageName, String compiler, MinicondaEnv menv) {
       menv
     )
 
-    wrapContainer(imageName, localImageName)
+    util.wrapContainer(imageName, localImageName)
 
     withEnv(["RUN=/scripts/${shBasename}", "IMAGE=${localImageName}"]) {
       shColor '''
@@ -304,7 +305,7 @@ def void linuxSmoke(String imageName, String compiler, MinicondaEnv menv) {
     ])
   }
 
-  wrapContainer(imageName, localImageName)
+  util.wrapContainer(imageName, localImageName)
 
   withEnv([
     "RUN=/scripts/${shBasename}",
@@ -721,52 +722,4 @@ def String joinPath(String ... parts) {
   }
 
   return text
-}
-
-/**
- * Create a thin "wrapper" container around {@code imageName} to map uid/gid of
- * the user invoking docker into the container.
- *
- * @param imageName docker image slug
- * @param tag name of tag to apply to generated image
- */
-def void wrapContainer(String imageName, String tag) {
-  def buildDir = 'docker'
-  def config = dedent("""
-    FROM    ${imageName}
-
-    ARG     USER
-    ARG     UID
-    ARG     GROUP
-    ARG     GID
-    ARG     HOME
-
-    USER    root
-    RUN     groupadd -g \$GID \$GROUP
-    RUN     useradd -d \$HOME -g \$GROUP -u \$UID \$USER
-
-    USER    \$USER
-    WORKDIR \$HOME
-  """)
-
-  // docker insists on recusrively checking file access under its execution
-  // path -- so run it from a dedicated dir
-  dir(buildDir) {
-    writeFile(file: 'Dockerfile', text: config)
-
-    shColor """
-      set -e
-      set -x
-
-      docker build -t "${tag}" \
-          --build-arg USER="\$(id -un)" \
-          --build-arg UID="\$(id -u)" \
-          --build-arg GROUP="\$(id -gn)" \
-          --build-arg GID="\$(id -g)" \
-          --build-arg HOME="\$HOME" \
-          .
-    """
-
-    deleteDir()
-  }
 }

--- a/pipelines/release/tarball.groovy
+++ b/pipelines/release/tarball.groovy
@@ -486,7 +486,7 @@ def String buildScript(
   MinicondaEnv menv
 ) {
   scriptPreamble(compiler, macosx_deployment_target, menv, true) +
-  dedent("""
+  util.dedent("""
     curl -sSL ${newinstall_url} | bash -s -- -cb
     . ./loadLSST.bash
 
@@ -514,7 +514,7 @@ def String smokeScript(
   String ciScriptsPath
 ) {
   scriptPreamble(compiler, macosx_deployment_target, menv, true) +
-  dedent("""
+  util.dedent("""
     export EUPS_PKGROOT="${eupsPkgroot}"
 
     curl -sSL ${newinstall_url} | bash -s -- -cb
@@ -545,7 +545,7 @@ def String scriptPreamble(
   MinicondaEnv menv,
   boolean useTarballs
 ) {
-  dedent("""
+  util.dedent("""
     set -e
     set -x
 
@@ -575,17 +575,6 @@ def String scriptPreamble(
     """
     + scriptCompiler(compiler)
   )
-}
-
-/**
- * Remove leading whitespace from a multi-line String (probably a shellscript).
- */
-@NonCPS
-def String dedent(String text) {
-  if (text == null) {
-    return null
-  }
-  text.replaceFirst("\n","").stripIndent()
 }
 
 /**
@@ -654,7 +643,7 @@ def String scriptCompiler(String compiler) {
       throw new UnsupportedCompiler(compiler)
   }
 
-  dedent(setup)
+  util.dedent(setup)
 }
 
 /**

--- a/pipelines/sqre/infrastructure/update_cmirror.groovy
+++ b/pipelines/sqre/infrastructure/update_cmirror.groovy
@@ -101,8 +101,12 @@ try {
 }
 
 def runMirror(String image, String upstream, String platform) {
+  def localImageName = "${image}-local"
+
+  util.wrapContainer(image, localImageName)
+
   withEnv([
-    "IMAGE=${image}",
+    "IMAGE=${localImageName}",
     "UPSTREAM=${upstream}",
     "PLATFORM=${platform}",
   ]) {

--- a/pipelines/sqre/infrastructure/update_cmirror.groovy
+++ b/pipelines/sqre/infrastructure/update_cmirror.groovy
@@ -7,6 +7,7 @@ node {
       userRemoteConfigs: scm.getUserRemoteConfigs()
     ])
     notify = load 'pipelines/lib/notify.groovy'
+    util = load 'pipelines/lib/util.groovy'
   }
 }
 
@@ -23,10 +24,10 @@ try {
     }
 
     stage('mirror linux-64') {
-      shColor '''
+      util.shColor '''
         mkdir -p local_mirror tmp
         chmod 777 local_mirror tmp
-      '''.replaceFirst("\n","").stripIndent()
+      '''
 
       runMirror(image.id, 'https://repo.continuum.io/pkgs/free/', 'linux-64')
     }
@@ -36,7 +37,7 @@ try {
     }
 
     stage('mirror miniconda') {
-      shColor '''
+      util.shColor '''
         wget \
           --mirror \
           --continue \
@@ -48,7 +49,7 @@ try {
           -R "*armv7l.sh" \
           -R "*x86.sh" \
           https://repo.continuum.io/miniconda/
-      '''.replaceFirst("\n","").stripIndent()
+      '''
     }
 
     stage('push to s3') {
@@ -63,7 +64,7 @@ try {
         credentialsId: 'cmirror-s3-bucket',
         variable: 'CMIRROR_S3_BUCKET'
       ]]) {
-        shColor '''
+        util.shColor '''
           set -e
           # do not assume virtualenv is present
           pip install virtualenv
@@ -73,7 +74,7 @@ try {
 
           aws s3 sync --delete ./local_mirror/ s3://$CMIRROR_S3_BUCKET/pkgs/free/
           aws s3 sync --delete ./miniconda/ s3://$CMIRROR_S3_BUCKET/miniconda/
-        '''.replaceFirst("\n","").stripIndent()
+        '''
       }
     } // stage('push to s3')
   } // node
@@ -105,7 +106,7 @@ def runMirror(String image, String upstream, String platform) {
     "UPSTREAM=${upstream}",
     "PLATFORM=${platform}",
   ]) {
-    shColor '''
+    util.shColor '''
       docker run \
         -v $(pwd)/tmp:/tmp \
         -v $(pwd)/local_mirror:/local_mirror \
@@ -114,12 +115,6 @@ def runMirror(String image, String upstream, String platform) {
         --target-directory /local_mirror \
         --platform "$PLATFORM" \
         -vvv
-    '''.replaceFirst("\n","").stripIndent()
-  }
-}
-
-def shColor(script) {
-  wrap([$class: 'AnsiColorBuildWrapper']) {
-    sh script
+    '''
   }
 }


### PR DESCRIPTION
Previously, this job was creating files on disk (via docker bind mounts) which
were not owned by the jenkins agent role user.  This was breaking with the
ability to cleanup the workspace(s).