### PR TITLE
do not set lfs.batch to false

### DIFF
--- a/jobs/validate_drp.groovy
+++ b/jobs/validate_drp.groovy
@@ -169,7 +169,10 @@ def j = matrixJob("${folder}/validate_drp") {
       }
 
       lfsconfig() {
-        git config --local lfs.batch false
+        # Remove local configuration of lfs.batch.  This was once required to
+        # be false with the sqre lfs server.  However, `false` will not break a
+        # lfs pull.
+        git config --local --unset lfs.batch
         # lfs.required must be false in order for jenkins to manage the clone
         git config --local filter.lfs.required false
         git config --local filter.lfs.smudge 'git-lfs smudge %f'


### PR DESCRIPTION
At one time, this setting was required with the sqre lfs server
implementation.  However, it now breaks the ability to pull.