### PR TITLE
do not use git shallow clone/fetch

### DIFF
--- a/jobs/jenkins_dm_jobs.groovy
+++ b/jobs/jenkins_dm_jobs.groovy
@@ -13,11 +13,13 @@ def j = job("${folder}/jenkins-dm-jobs") {
         url(repo)
       }
       branch(ref)
+      /*
       extensions {
         cloneOptions {
           shallow(true)
         }
       }
+      */
     }
   }
 

--- a/jobs/jenkins_ebs_snapshot.groovy
+++ b/jobs/jenkins_ebs_snapshot.groovy
@@ -15,11 +15,13 @@ def j = job("${folder}/jenkins-ebs-snapshot") {
         //refspec('+refs/pull/*:refs/remotes/origin/pr/*')
       }
       branch('*/master')
+      /*
       extensions {
         cloneOptions {
           shallow(true)
         }
       }
+      */
     }
   }
 

--- a/jobs/stack_os_matrix.groovy
+++ b/jobs/stack_os_matrix.groovy
@@ -54,7 +54,7 @@ def j = matrixJob('stack-os-matrix') {
       branch('*/master')
       extensions {
         relativeTargetDirectory('lsstsw')
-        cloneOptions { shallow() }
+        // cloneOptions { shallow() }
       }
     }
     git {
@@ -64,7 +64,7 @@ def j = matrixJob('stack-os-matrix') {
       branch('*/master')
       extensions {
         relativeTargetDirectory('buildbot-scripts')
-        cloneOptions { shallow() }
+        // cloneOptions { shallow() }
       }
     }
   }

--- a/jobs/validate_drp.groovy
+++ b/jobs/validate_drp.groovy
@@ -23,7 +23,7 @@ def j = matrixJob("${folder}/validate_drp") {
       branch('*/master')
       extensions {
         relativeTargetDirectory('lsstsw')
-        cloneOptions { shallow() }
+        // cloneOptions { shallow() }
       }
     }
     git {
@@ -33,7 +33,7 @@ def j = matrixJob("${folder}/validate_drp") {
       branch('*/master')
       extensions {
         relativeTargetDirectory('buildbot-scripts')
-        cloneOptions { shallow() }
+        // cloneOptions { shallow() }
       }
     }
     // jenkins can't properly clone a git-lfs repo (yet) due to the way it
@@ -47,7 +47,7 @@ def j = matrixJob("${folder}/validate_drp") {
       branch('*/master')
       extensions {
         relativeTargetDirectory('validation_data_hsc')
-        cloneOptions { shallow() }
+        // cloneOptions { shallow() }
       }
     }
   }


### PR DESCRIPTION
jenkins started failing to fetch on pre-existing lsst/lsstsw clones this
morning.  This is first time this failure mode has been observed.

This jenkins jira issue suggests that the problem is specific to the
version of git shipped with el7 when doing a shallow clone/fetch over
http[s]:

https://issues.jenkins-ci.org/browse/JENKINS-37229

Current jenkins master:

    $ cat /etc/redhat-release
    CentOS Linux release 7.1.1503 (Core)

    $ git --version
    git version 1.8.3.1

    $ git fetch --tags --progress https://github.com/lsst/lsstsw.git +refs/heads/*:refs/remotes/origin/* --depth=1 --verbose
    POST git-upload-pack (gzip 16429 to 5558 bytes)
    POST git-upload-pack (gzip 17233 to 5661 bytes)
    POST git-upload-pack (gzip 18033 to 5754 bytes)
    POST git-upload-pack (gzip 19633 to 5938 bytes)
    POST git-upload-pack (gzip 22833 to 6302 bytes)
    fatal: git fetch-pack: expected shallow list