### PR TITLE
do not fail immediate on qserv container build

### DIFF
--- a/pipelines/release/weekly_release.groovy
+++ b/pipelines/release/weekly_release.groovy
@@ -100,8 +100,10 @@ try {
     }
 
     artifact['run qserv/docker/build'] = {
-      retry(retries) {
-        build job: 'qserv/docker/build'
+      catchError {
+        retry(retries) {
+          build job: 'qserv/docker/build'
+        }
       }
     }
 


### PR DESCRIPTION
The qserv container build has been failing for weeks.  As no later stage
depends on the qserv containers, it is safe to proceed with subsequent
stages before marking the build as failed.