### PR TITLE
improved github-tag-version error handling

### DIFF
--- a/jobs/tag_git_repos.groovy
+++ b/jobs/tag_git_repos.groovy
@@ -41,6 +41,7 @@ def j = job('release/tag-git-repos') {
       ARGS+=('--team' 'Data Management')
       ARGS+=('--email' 'sqre-admin@lists.lsst.org')
       ARGS+=('--tagger' 'sqreadmin')
+      ARGS+=('--fail-fast')
       ARGS+=('--debug')
       ARGS+=("$GIT_TAG")
       ARGS+=("$BUILD_ID")

--- a/jobs/tag_git_repos.groovy
+++ b/jobs/tag_git_repos.groovy
@@ -47,7 +47,7 @@ def j = job('release/tag-git-repos') {
 
       virtualenv venv
       . venv/bin/activate
-      pip install sqre-codekit==3.0.0
+      pip install sqre-codekit==3.1.0
 
       # do not echo GH token to console log
       set +x


### PR DESCRIPTION
github-tag-version would silently fail / continue past failed github repo tags.
As of 3.1.0, github-tag-version will have a non-zero exit status if any tag
operation fails.  Additionally, the new `--fail-fast` option flag will cause
github-tag-version to exit upon the first encountered error instead of attempt
to process all repos.