### PR TITLE
restrict lib clones of jenkins-dm-jobs to jenkins-master

### DIFF
--- a/pipelines/qserv/docker/build_dev.groovy
+++ b/pipelines/qserv/docker/build_dev.groovy
@@ -1,5 +1,6 @@
 def notify = null
-node {
+
+node('jenkins-master') {
   dir('jenkins-dm-jobs') {
     // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([

--- a/pipelines/qserv/docker/build_release.groovy
+++ b/pipelines/qserv/docker/build_release.groovy
@@ -1,5 +1,6 @@
 def notify = null
-node {
+
+node('jenkins-master') {
   dir('jenkins-dm-jobs') {
     // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([

--- a/pipelines/qserv/release/tag_latest+dev.groovy
+++ b/pipelines/qserv/release/tag_latest+dev.groovy
@@ -1,5 +1,6 @@
 def notify = null
-node {
+
+node('jenkins-master') {
   dir('jenkins-dm-jobs') {
     // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([

--- a/pipelines/qserv/release/tag_qserv_dev.groovy
+++ b/pipelines/qserv/release/tag_qserv_dev.groovy
@@ -1,5 +1,6 @@
 def notify = null
-node {
+
+node('jenkins-master') {
   dir('jenkins-dm-jobs') {
     // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([

--- a/pipelines/qserv/release/tag_qserv_latest.groovy
+++ b/pipelines/qserv/release/tag_qserv_latest.groovy
@@ -1,5 +1,6 @@
 def notify = null
-node {
+
+node('jenkins-master') {
   dir('jenkins-dm-jobs') {
     // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([

--- a/pipelines/release/build_publish.groovy
+++ b/pipelines/release/build_publish.groovy
@@ -1,5 +1,6 @@
 def notify = null
-node {
+
+node('jenkins-master') {
   dir('jenkins-dm-jobs') {
     // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([

--- a/pipelines/release/build_publish_tag.groovy
+++ b/pipelines/release/build_publish_tag.groovy
@@ -1,5 +1,6 @@
 def notify = null
-node {
+
+node('jenkins-master') {
   dir('jenkins-dm-jobs') {
     // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([

--- a/pipelines/release/nightly_release.groovy
+++ b/pipelines/release/nightly_release.groovy
@@ -1,5 +1,6 @@
 def notify = null
-node {
+
+node('jenkins-master') {
   dir('jenkins-dm-jobs') {
     // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([

--- a/pipelines/release/nightly_release_cron.groovy
+++ b/pipelines/release/nightly_release_cron.groovy
@@ -1,5 +1,6 @@
 def notify = null
-node {
+
+node('jenkins-master') {
   dir('jenkins-dm-jobs') {
     // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([

--- a/pipelines/release/weekly_release.groovy
+++ b/pipelines/release/weekly_release.groovy
@@ -1,5 +1,6 @@
 def notify = null
-node {
+
+node('jenkins-master') {
   dir('jenkins-dm-jobs') {
     // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([

--- a/pipelines/release/weekly_release_cron.groovy
+++ b/pipelines/release/weekly_release_cron.groovy
@@ -1,5 +1,6 @@
 def notify = null
-node {
+
+node('jenkins-master') {
   dir('jenkins-dm-jobs') {
     // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([

--- a/pipelines/sqre/backup/build_mysqldump_to_s3.groovy
+++ b/pipelines/sqre/backup/build_mysqldump_to_s3.groovy
@@ -1,5 +1,6 @@
 def notify = null
-node {
+
+node('jenkins-master') {
   dir('jenkins-dm-jobs') {
     checkout([
       $class: 'GitSCM',

--- a/pipelines/sqre/backup/build_s3backup.groovy
+++ b/pipelines/sqre/backup/build_s3backup.groovy
@@ -1,5 +1,6 @@
 def notify = null
-node {
+
+node('jenkins-master') {
   dir('jenkins-dm-jobs') {
     checkout([
       $class: 'GitSCM',

--- a/pipelines/sqre/backup/build_sqre_github_snapshot.groovy
+++ b/pipelines/sqre/backup/build_sqre_github_snapshot.groovy
@@ -1,5 +1,6 @@
 def notify = null
-node {
+
+node('jenkins-master') {
   dir('jenkins-dm-jobs') {
     checkout([
       $class: 'GitSCM',

--- a/pipelines/sqre/backup/nightly_sqre_github_snapshot.groovy
+++ b/pipelines/sqre/backup/nightly_sqre_github_snapshot.groovy
@@ -1,5 +1,6 @@
 def notify = null
-node {
+
+node('jenkins-master') {
   dir('jenkins-dm-jobs') {
     checkout([
       $class: 'GitSCM',

--- a/pipelines/sqre/backup/qadb_dump.groovy
+++ b/pipelines/sqre/backup/qadb_dump.groovy
@@ -1,5 +1,6 @@
 def notify = null
-node {
+
+node('jenkins-master') {
   dir('jenkins-dm-jobs') {
     checkout([
       $class: 'GitSCM',

--- a/pipelines/sqre/backup/s3backup_eups.groovy
+++ b/pipelines/sqre/backup/s3backup_eups.groovy
@@ -1,5 +1,6 @@
 def notify = null
-node {
+
+node('jenkins-master') {
   dir('jenkins-dm-jobs') {
     checkout([
       $class: 'GitSCM',

--- a/pipelines/sqre/ci_ci/test_pipeline_docker.groovy
+++ b/pipelines/sqre/ci_ci/test_pipeline_docker.groovy
@@ -1,5 +1,6 @@
 def notify = null
-node {
+
+node('jenkins-master') {
   dir('jenkins-dm-jobs') {
     // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([

--- a/pipelines/sqre/ci_ci/test_pipeline_write.groovy
+++ b/pipelines/sqre/ci_ci/test_pipeline_write.groovy
@@ -1,5 +1,6 @@
 def notify = null
-node {
+
+node('jenkins-master') {
   dir('jenkins-dm-jobs') {
     // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([

--- a/pipelines/sqre/infrastructure/build_cmirror.groovy
+++ b/pipelines/sqre/infrastructure/build_cmirror.groovy
@@ -1,5 +1,6 @@
 def notify = null
-node {
+
+node('jenkins-master') {
   dir('jenkins-dm-jobs') {
     checkout([
       $class: 'GitSCM',

--- a/pipelines/sqre/infrastructure/build_jupyterlabdemo.groovy
+++ b/pipelines/sqre/infrastructure/build_jupyterlabdemo.groovy
@@ -1,5 +1,6 @@
 def notify = null
-node {
+
+node('jenkins-master') {
   dir('jenkins-dm-jobs') {
     checkout([
       $class: 'GitSCM',

--- a/pipelines/sqre/infrastructure/build_nginx_ssl_proxy.groovy
+++ b/pipelines/sqre/infrastructure/build_nginx_ssl_proxy.groovy
@@ -1,5 +1,6 @@
 def notify = null
-node {
+
+node('jenkins-master') {
   dir('jenkins-dm-jobs') {
     checkout([
       $class: 'GitSCM',

--- a/pipelines/sqre/infrastructure/build_stacktest.groovy
+++ b/pipelines/sqre/infrastructure/build_stacktest.groovy
@@ -1,5 +1,6 @@
 def notify = null
-node {
+
+node('jenkins-master') {
   dir('jenkins-dm-jobs') {
     checkout([
       $class: 'GitSCM',

--- a/pipelines/sqre/infrastructure/travissync.groovy
+++ b/pipelines/sqre/infrastructure/travissync.groovy
@@ -1,5 +1,6 @@
 def notify = null
-node {
+
+node('jenkins-master') {
   dir('jenkins-dm-jobs') {
     checkout([
       $class: 'GitSCM',

--- a/pipelines/sqre/infrastructure/update_cmirror.groovy
+++ b/pipelines/sqre/infrastructure/update_cmirror.groovy
@@ -1,5 +1,6 @@
 def notify = null
-node {
+
+node('jenkins-master') {
   dir('jenkins-dm-jobs') {
     checkout([
       $class: 'GitSCM',


### PR DESCRIPTION
Thus not tying up a beefy worker node.