### PR TITLE
fix exception handling

### DIFF
--- a/scripts/sqre/infrastructure/jenkins_node_cleanup.groovy
+++ b/scripts/sqre/infrastructure/jenkins_node_cleanup.groovy
@@ -189,7 +189,7 @@ for (node in Jenkins.instance.nodes) {
         }
       }
     }
-  } catch (Throwable t) {
+  } catch (Node t) {
     switch (t) {
       case Offline:
         nodeStatus['offlineNodes'] << t

--- a/scripts/sqre/infrastructure/jenkins_node_cleanup.groovy
+++ b/scripts/sqre/infrastructure/jenkins_node_cleanup.groovy
@@ -146,7 +146,7 @@ for (node in Jenkins.instance.nodes) {
       // have run on this node in the past
 
       // select all jobs with a custom workspace
-      def custom = allJobs.findAll { item -> item.getCustomWorkspace() }
+      def custom = allJobs().findAll { item -> item.getCustomWorkspace() }
       custom.each { item ->
         // note that #child claims to deal with abs and rel paths
         if (!deleteRemote(node.getRootPath().child(item.customWorkspace()), false)) {
@@ -163,7 +163,7 @@ for (node in Jenkins.instance.nodes) {
       // node has at least one active job
 
       // find all jobs that are *not* building
-      def idleJobs = allJobs.findAll { item -> !item.isBuilding() }
+      def idleJobs = allJobs().findAll { item -> !item.isBuilding() }
 
       idleJobs.each { item ->
         def jobName = item.getFullDisplayName()


### PR DESCRIPTION
Groovy was interpreting `allJobs` as a property lookup rather than as a method
invocation.  Changing to `allJobs()` forces groovy to treat the statement as a
method call.  This problem was being masked by an overzealous catch block,
which was catching the missing property exception then assuming the exception
type was a Node, resulting in an NPE.