### PR TITLE
run stack "wrapper" cron outside buisness hours

### DIFF
--- a/jobs/util/StackOsMatrix.groovy
+++ b/jobs/util/StackOsMatrix.groovy
@@ -7,7 +7,7 @@ class StackOsMatrix {
   String name
   String product
   Boolean skip_demo
-  String cron = 'H H/8 * * *'
+  String cron = 'H H(0-4) * * *'
   String branch
   String triggerJob = 'stack-os-matrix'
 


### PR DESCRIPTION
This moves from 3 randomly distributed builds per product per day to a
single build per day between 0000 - 0400 project / pacific time.