### PR TITLE
disable tarball job retrying

### DIFF
--- a/pipelines/release/tarball.groovy
+++ b/pipelines/release/tarball.groovy
@@ -25,7 +25,7 @@ node {
 
 try {
   notify.started()
-  def retries = 3
+  def retries = 1
 
   if (!params.PYVER) {
     error 'PYVER parameter is required'


### PR DESCRIPTION
The weekly/nightly triggering jobs were also trying the tarball build,
resulting in excessive retry attempts.