### PR TITLE
partially suppress changelog notifications

### DIFF
--- a/pipelines/lib/util.groovy
+++ b/pipelines/lib/util.groovy
@@ -159,14 +159,18 @@ def lsstswBuild(String label, String python) {
           dir('lsstsw') {
             git([
               url: 'https://github.com/lsst/lsstsw.git',
-              branch: 'master'
+              branch: 'master',
+              changelog: false,
+              poll: false
             ])
           }
 
           dir('buildbot-scripts') {
             git([
               url: 'https://github.com/lsst-sqre/buildbot-scripts.git',
-              branch: 'master'
+              branch: 'master',
+              changelog: false,
+              poll: false
             ])
           }
 

--- a/pipelines/newinstall/docker/build.groovy
+++ b/pipelines/newinstall/docker/build.groovy
@@ -2,11 +2,12 @@ def notify = null
 
 node('jenkins-master') {
   dir('jenkins-dm-jobs') {
-    // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
     util = load 'pipelines/lib/util.groovy'

--- a/pipelines/newinstall/docker/newinstall.groovy
+++ b/pipelines/newinstall/docker/newinstall.groovy
@@ -2,11 +2,12 @@ def notify = null
 
 node('jenkins-master') {
   dir('jenkins-dm-jobs') {
-    // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
     util = load 'pipelines/lib/util.groovy'

--- a/pipelines/newinstall/docker/prepare.groovy
+++ b/pipelines/newinstall/docker/prepare.groovy
@@ -2,11 +2,12 @@ def notify = null
 
 node('jenkins-master') {
   dir('jenkins-dm-jobs') {
-    // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
     util = load 'pipelines/lib/util.groovy'

--- a/pipelines/qserv/docker/build_dev.groovy
+++ b/pipelines/qserv/docker/build_dev.groovy
@@ -2,11 +2,12 @@ def notify = null
 
 node('jenkins-master') {
   dir('jenkins-dm-jobs') {
-    // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
     util = load 'pipelines/lib/util.groovy'

--- a/pipelines/qserv/docker/build_release.groovy
+++ b/pipelines/qserv/docker/build_release.groovy
@@ -2,11 +2,12 @@ def notify = null
 
 node('jenkins-master') {
   dir('jenkins-dm-jobs') {
-    // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
     util = load 'pipelines/lib/util.groovy'

--- a/pipelines/qserv/release/tag_latest+dev.groovy
+++ b/pipelines/qserv/release/tag_latest+dev.groovy
@@ -2,11 +2,12 @@ def notify = null
 
 node('jenkins-master') {
   dir('jenkins-dm-jobs') {
-    // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
   }

--- a/pipelines/qserv/release/tag_qserv_dev.groovy
+++ b/pipelines/qserv/release/tag_qserv_dev.groovy
@@ -2,11 +2,12 @@ def notify = null
 
 node('jenkins-master') {
   dir('jenkins-dm-jobs') {
-    // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
   }

--- a/pipelines/qserv/release/tag_qserv_latest.groovy
+++ b/pipelines/qserv/release/tag_qserv_latest.groovy
@@ -2,11 +2,12 @@ def notify = null
 
 node('jenkins-master') {
   dir('jenkins-dm-jobs') {
-    // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
   }

--- a/pipelines/release/build_publish.groovy
+++ b/pipelines/release/build_publish.groovy
@@ -2,11 +2,12 @@ def notify = null
 
 node('jenkins-master') {
   dir('jenkins-dm-jobs') {
-    // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
   }

--- a/pipelines/release/build_publish_tag.groovy
+++ b/pipelines/release/build_publish_tag.groovy
@@ -2,11 +2,12 @@ def notify = null
 
 node('jenkins-master') {
   dir('jenkins-dm-jobs') {
-    // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
   }

--- a/pipelines/release/nightly_release.groovy
+++ b/pipelines/release/nightly_release.groovy
@@ -2,11 +2,12 @@ def notify = null
 
 node('jenkins-master') {
   dir('jenkins-dm-jobs') {
-    // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
     util = load 'pipelines/lib/util.groovy'

--- a/pipelines/release/nightly_release_cron.groovy
+++ b/pipelines/release/nightly_release_cron.groovy
@@ -2,11 +2,12 @@ def notify = null
 
 node('jenkins-master') {
   dir('jenkins-dm-jobs') {
-    // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
   }

--- a/pipelines/release/run_publish.groovy
+++ b/pipelines/release/run_publish.groovy
@@ -23,14 +23,18 @@ try {
         dir('lsstsw') {
           git([
             url: 'https://github.com/lsst/lsstsw.git',
-            branch: 'master'
+            branch: 'master',
+            changelog: false,
+            poll: false
           ])
         }
 
         dir('buildbot-scripts') {
           git([
             url: 'https://github.com/lsst-sqre/buildbot-scripts.git',
-            branch: 'master'
+            branch: 'master',
+            changelog: false,
+            poll: false
           ])
         }
 

--- a/pipelines/release/run_publish.groovy
+++ b/pipelines/release/run_publish.groovy
@@ -2,11 +2,12 @@ def notify = null
 
 node('jenkins-master') {
   dir('jenkins-dm-jobs') {
-    // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
     util = load 'pipelines/lib/util.groovy'

--- a/pipelines/release/run_rebuild.groovy
+++ b/pipelines/release/run_rebuild.groovy
@@ -2,11 +2,12 @@ def notify = null
 
 node('jenkins-master') {
   dir('jenkins-dm-jobs') {
-    // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
     util = load 'pipelines/lib/util.groovy'

--- a/pipelines/release/run_rebuild.groovy
+++ b/pipelines/release/run_rebuild.groovy
@@ -24,14 +24,18 @@ try {
           dir('lsstsw') {
             git([
               url: 'https://github.com/lsst/lsstsw.git',
-              branch: 'master'
+              branch: 'master',
+              changelog: false,
+              poll: false
             ])
           }
 
           dir('buildbot-scripts') {
             git([
               url: 'https://github.com/lsst-sqre/buildbot-scripts.git',
-              branch: 'master'
+              branch: 'master',
+              changelog: false,
+              poll: false
             ])
           }
 

--- a/pipelines/release/tarball.groovy
+++ b/pipelines/release/tarball.groovy
@@ -9,11 +9,12 @@ node {
   }
 
   dir('jenkins-dm-jobs') {
-    // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
     util = load 'pipelines/lib/util.groovy'

--- a/pipelines/release/weekly_release.groovy
+++ b/pipelines/release/weekly_release.groovy
@@ -2,11 +2,12 @@ def notify = null
 
 node('jenkins-master') {
   dir('jenkins-dm-jobs') {
-    // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
     util = load 'pipelines/lib/util.groovy'

--- a/pipelines/release/weekly_release_cron.groovy
+++ b/pipelines/release/weekly_release_cron.groovy
@@ -2,11 +2,12 @@ def notify = null
 
 node('jenkins-master') {
   dir('jenkins-dm-jobs') {
-    // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
   }

--- a/pipelines/science_pipelines/py2_boondocks.groovy
+++ b/pipelines/science_pipelines/py2_boondocks.groovy
@@ -2,11 +2,12 @@ def notify = null
 
 node('jenkins-master') {
   dir('jenkins-dm-jobs') {
-    // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
     util = load 'pipelines/lib/util.groovy'

--- a/pipelines/sqre/backup/build_mysqldump_to_s3.groovy
+++ b/pipelines/sqre/backup/build_mysqldump_to_s3.groovy
@@ -5,7 +5,9 @@ node('jenkins-master') {
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
   }

--- a/pipelines/sqre/backup/build_s3backup.groovy
+++ b/pipelines/sqre/backup/build_s3backup.groovy
@@ -5,7 +5,9 @@ node('jenkins-master') {
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
   }

--- a/pipelines/sqre/backup/build_sqre_github_snapshot.groovy
+++ b/pipelines/sqre/backup/build_sqre_github_snapshot.groovy
@@ -5,7 +5,9 @@ node('jenkins-master') {
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
   }

--- a/pipelines/sqre/backup/nightly_sqre_github_snapshot.groovy
+++ b/pipelines/sqre/backup/nightly_sqre_github_snapshot.groovy
@@ -5,7 +5,9 @@ node('jenkins-master') {
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
   }

--- a/pipelines/sqre/backup/qadb_dump.groovy
+++ b/pipelines/sqre/backup/qadb_dump.groovy
@@ -5,7 +5,9 @@ node('jenkins-master') {
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
   }

--- a/pipelines/sqre/backup/s3backup_eups.groovy
+++ b/pipelines/sqre/backup/s3backup_eups.groovy
@@ -5,7 +5,9 @@ node('jenkins-master') {
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
   }

--- a/pipelines/sqre/ci_ci/test_pipe.groovy
+++ b/pipelines/sqre/ci_ci/test_pipe.groovy
@@ -2,11 +2,12 @@ def notify = null
 
 node('jenkins-master') {
   dir('jenkins-dm-jobs') {
-    // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
   }

--- a/pipelines/sqre/ci_ci/test_pipeline_docker.groovy
+++ b/pipelines/sqre/ci_ci/test_pipeline_docker.groovy
@@ -2,11 +2,12 @@ def notify = null
 
 node('jenkins-master') {
   dir('jenkins-dm-jobs') {
-    // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
   }

--- a/pipelines/sqre/ci_ci/test_pipeline_write.groovy
+++ b/pipelines/sqre/ci_ci/test_pipeline_write.groovy
@@ -2,11 +2,12 @@ def notify = null
 
 node('jenkins-master') {
   dir('jenkins-dm-jobs') {
-    // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
   }

--- a/pipelines/sqre/infrastructure/build_cmirror.groovy
+++ b/pipelines/sqre/infrastructure/build_cmirror.groovy
@@ -5,7 +5,9 @@ node('jenkins-master') {
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
   }

--- a/pipelines/sqre/infrastructure/build_jupyterlabdemo.groovy
+++ b/pipelines/sqre/infrastructure/build_jupyterlabdemo.groovy
@@ -5,7 +5,9 @@ node('jenkins-master') {
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
     util = load 'pipelines/lib/util.groovy'

--- a/pipelines/sqre/infrastructure/build_nginx_ssl_proxy.groovy
+++ b/pipelines/sqre/infrastructure/build_nginx_ssl_proxy.groovy
@@ -5,7 +5,9 @@ node('jenkins-master') {
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
   }

--- a/pipelines/sqre/infrastructure/build_stacktest.groovy
+++ b/pipelines/sqre/infrastructure/build_stacktest.groovy
@@ -5,7 +5,9 @@ node('jenkins-master') {
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
     util = load 'pipelines/lib/util.groovy'

--- a/pipelines/sqre/infrastructure/travissync.groovy
+++ b/pipelines/sqre/infrastructure/travissync.groovy
@@ -5,7 +5,9 @@ node('jenkins-master') {
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
   }

--- a/pipelines/sqre/infrastructure/update_cmirror.groovy
+++ b/pipelines/sqre/infrastructure/update_cmirror.groovy
@@ -5,7 +5,9 @@ node('jenkins-master') {
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
     util = load 'pipelines/lib/util.groovy'

--- a/pipelines/stack_os_matrix.groovy
+++ b/pipelines/stack_os_matrix.groovy
@@ -2,11 +2,12 @@ def notify = null
 
 node('jenkins-master') {
   dir('jenkins-dm-jobs') {
-    // XXX the git step seemed to blowup on a branch of '*/<foo>'
     checkout([
       $class: 'GitSCM',
       branches: scm.getBranches(),
-      userRemoteConfigs: scm.getUserRemoteConfigs()
+      userRemoteConfigs: scm.getUserRemoteConfigs(),
+      changelog: false,
+      poll: false
     ])
     notify = load 'pipelines/lib/notify.groovy'
     util = load 'pipelines/lib/util.groovy'


### PR DESCRIPTION
This will suppress the changelog for the lsstsw & buildbot-script checkout but does not remove the changelog from the pipeline script checkout via scm.