### PR TITLE
use RUN_DISPLAY_URL instead of BUILD_URL in notifications links

### DIFF
--- a/jobs/util/Common.groovy
+++ b/jobs/util/Common.groovy
@@ -20,7 +20,7 @@ class Common {
           startNotification(true)
           includeTestSummary(false)
           includeCustomMessage(true)
-          customMessage('(<${BUILD_URL}/console|Console>)')
+          customMessage('(<${RUN_DISPLAY_URL}/console|Console>)')
           sendAs(null)
           commitInfoChoice('NONE')
           teamDomain(null)

--- a/pipelines/lib/notify.groovy
+++ b/pipelines/lib/notify.groovy
@@ -17,7 +17,7 @@ String duration() {
 }
 
 String slackMessage(String detail) {
-  "${env.JOB_NAME} - #${env.BUILD_NUMBER} ${detail} (<${env.BUILD_URL}|Open>) (<${env.BUILD_URL}/console|Console>)"
+  "${env.JOB_NAME} - #${env.BUILD_NUMBER} ${detail} (<${env.RUN_DISPLAY_URL}|Open>)"
 }
 
 String slackStartMessage() {


### PR DESCRIPTION
RUN_DISPLAY_URL is introduced by blueocean as a replacement for
BUILD_URL.  Which may be configured globally and per-user between
redirecting to blueocean or the "classic" UI.