### PR TITLE
explicitly declare EUPS_USERDATA

### DIFF
--- a/pipelines/lib/util.groovy
+++ b/pipelines/lib/util.groovy
@@ -221,6 +221,7 @@ def jenkinsWrapper() {
         withEnv([
           "WORKSPACE=${pwd()}",
           "HOME=${pwd()}/home",
+          "EUPS_USERDATA=${pwd()}/home/.eups_userdata",
         ]) {
           util.shColor './buildbot-scripts/jenkins_wrapper.sh'
         }


### PR DESCRIPTION
Using a non-default name as a "future" debugging aid to detect if this env var isn't being respected.