### PR TITLE
push tarball build timeout(s) into node blocks

### DIFF
--- a/jobs/tarball.groovy
+++ b/jobs/tarball.groovy
@@ -16,6 +16,7 @@ pipelineJob('release/tarball') {
     choiceParam('MINIVER', ['4.3.21', '4.2.12'], 'Miniconda installer version')
     choiceParam('LSSTSW_REF', ['10a4fa6', '7c8e67'], 'LSST conda package set ref')
     choiceParam('OS', ['centos-7', 'centos-6', 'osx-10.11'], 'LSST conda package set ref')
+    stringParam('TIMEOUT', '6', 'build timeout in hours')
   }
 
   properties {

--- a/pipelines/release/nightly_release.groovy
+++ b/pipelines/release/nightly_release.groovy
@@ -151,21 +151,20 @@ try {
           pyenv.each { py ->
             platform["${os}.${py.slug()}"] = {
               retry(retries) {
-                timeout(time: 6, unit: 'HOURS') {
-                  build job: 'release/tarball',
-                    parameters: [
-                      string(name: 'PRODUCT', value: 'lsst_distrib'),
-                      string(name: 'EUPS_TAG', value: eupsTag),
-                      booleanParam(name: 'SMOKE', value: true),
-                      booleanParam(name: 'RUN_DEMO', value: true),
-                      booleanParam(name: 'RUN_SCONS_CHECK', value: true),
-                      booleanParam(name: 'PUBLISH', value: true),
-                      string(name: 'PYVER', value: py.pythonVersion),
-                      string(name: 'MINIVER', value: py.minicondaVersion),
-                      string(name: 'LSSTSW_REF', value: py.lsstswRef),
-                      string(name: 'OS', value: os),
-                    ]
-                }
+                build job: 'release/tarball',
+                  parameters: [
+                    string(name: 'PRODUCT', value: 'lsst_distrib'),
+                    string(name: 'EUPS_TAG', value: eupsTag),
+                    booleanParam(name: 'SMOKE', value: true),
+                    booleanParam(name: 'RUN_DEMO', value: true),
+                    booleanParam(name: 'RUN_SCONS_CHECK', value: true),
+                    booleanParam(name: 'PUBLISH', value: true),
+                    string(name: 'PYVER', value: py.pythonVersion),
+                    string(name: 'MINIVER', value: py.minicondaVersion),
+                    string(name: 'LSSTSW_REF', value: py.lsstswRef),
+                    string(name: 'OS', value: os),
+                    string(name: 'TIMEOUT', value: '6'), // hours
+                  ]
               }
             }
           }

--- a/pipelines/release/tarball_matrix.groovy
+++ b/pipelines/release/tarball_matrix.groovy
@@ -65,6 +65,7 @@ try {
                     string(name: 'MINIVER', value: py.minicondaVersion),
                     string(name: 'LSSTSW_REF', value: py.lsstswRef),
                     string(name: 'OS', value: os),
+                    string(name: 'TIMEOUT', value: '6'), // hours
                   ]
               }
             }


### PR DESCRIPTION
This is to avoid the build timeout timer starting from the moment the
build is triggered rather than from when "work" is started.