### PR TITLE
fix mirror() failing to pass through platform arg

### DIFF
--- a/pipelines/sqre/infrastructure/update_cmirror.groovy
+++ b/pipelines/sqre/infrastructure/update_cmirror.groovy
@@ -120,7 +120,7 @@ try {
 
 def mirror(String imageId, String upstream, String platform) {
   stage("mirror ${platform}") {
-    runMirror(imageId, 'https://repo.continuum.io/pkgs/free/', 'osx-64')
+    runMirror(imageId, 'https://repo.continuum.io/pkgs/free/', platform)
   }
 }
 


### PR DESCRIPTION
This method was intended to pass through the 'platform' arg to the
runMirror() method but had an accidental hard coded value.