### PR TITLE
remove push s3 doc push cleanup

### DIFF
--- a/pipelines/release/run_rebuild.groovy
+++ b/pipelines/release/run_rebuild.groovy
@@ -71,9 +71,6 @@ try {
               . ./buildbot-scripts/settings.cfg.sh
 
               aws s3 cp --recursive "$DOC_PUSH_PATH"/ s3://$DOXYGEN_S3_BUCKET/stack/doxygen/
-
-              # prevent unbounded accumulation of doc builds
-              rm -rf "$DOC_PUSH_PATH"
             '''
           }
         }


### PR DESCRIPTION
This is no longer nessicary due to the alternative $HOME path, which is
deleted between builds.