### PR TITLE
add BRANCH matrix axis

### DIFF
--- a/jobs/validate_drp.groovy
+++ b/jobs/validate_drp.groovy
@@ -64,6 +64,7 @@ def j = matrixJob("${folder}/validate_drp") {
     //text('dataset', 'cfht', 'hsc', 'decam')
     text('dataset', 'cfht', 'hsc')
     text('python', 'py3')
+    text('BRANCH', '', 'tickets/DM-12253') // '' == master
   }
 
   combinationFilter('!(label=="centos-6" && python=="py3")')


### PR DESCRIPTION
The 'jenkins_wrapper.sh' script will respond to an env var named
'BRANCH', so everything should 'just work' by adding a new axis named
'BRANCH', which will cause an env var to be defined of the same name.