### PR TITLE
invoke `eups distrib install` with single product name

### DIFF
--- a/pipelines/release/tarball.groovy
+++ b/pipelines/release/tarball.groovy
@@ -507,10 +507,12 @@ def String buildScript(
     curl -sSL ${newinstall_url} | bash -s -- -cb
     . ./loadLSST.bash
 
-    eups distrib install ${products} -t "${tag}" -vvv
+    for prod in "${products}"; do
+      eups distrib install ${products} -t "${tag}" -vvv
+    done
 
     export EUPS_PKGROOT="${eupsPkgroot}"
-    for product in "${products}"; do
+    for prod in "${products}"; do
       eups distrib create --server-dir "\$EUPS_PKGROOT" -d tarball "\$product" -t "${tag}" -vvv
     done
     eups distrib declare --server-dir "\$EUPS_PKGROOT" -t "${tag}" -vvv
@@ -540,7 +542,9 @@ def String smokeScript(
     # override newinstall.sh configured EUPS_PKGROOT
     export EUPS_PKGROOT="${eupsPkgroot}"
 
-    eups distrib install ${products} -t "${tag}" -vvv
+    for prod in "${products}"; do
+      eups distrib install ${products} -t "${tag}" -vvv
+    done
 
     if [[ \$FIX_SHEBANGS == true ]]; then
       curl -sSL ${shebangtron_url} | python


### PR DESCRIPTION
It seems that EUPS distrib will not accept multiple package names
simultaneously. Eg.

    [lsst@3642bbddd8ef stack]$ eups distrib install afw base  -t d_2017_11_06 -vvvAcquiring exclusive locks for command "distrib install"
    Creating lock directory /opt/lsst/software/stack/stack/miniconda3-4.3.21-10a4fa6/.lockDir
    Reading tags from /opt/lsst/software/stack/stack/miniconda3-4.3.21-10a4fa6/ups_db/global.tags
    Using VRO for "default": ['type:exact', 'commandLine', 'version', 'versionExpr', 'current']
    Reading configuration data from /opt/lsst/software/stack/stack/miniconda3-4.3.21-10a4fa6/ups_db/_servers_/https://eups.lsst.codes/stack/src/config.txt
    eups distrib: Product afw base not found in any package repository
    Removing lockfile /opt/lsst/software/stack/stack/miniconda3-4.3.21-10a4fa6/.lockDir/exclusive-lsst.17903