### PR TITLE
fix eups distrib execution loops

### DIFF
--- a/pipelines/release/tarball.groovy
+++ b/pipelines/release/tarball.groovy
@@ -508,7 +508,7 @@ def String buildScript(
     . ./loadLSST.bash
 
     for prod in ${products}; do
-      eups distrib install ${products} -t "${tag}" -vvv
+      eups distrib install "$prod" -t "${tag}" -vvv
     done
 
     export EUPS_PKGROOT="${eupsPkgroot}"
@@ -543,7 +543,7 @@ def String smokeScript(
     export EUPS_PKGROOT="${eupsPkgroot}"
 
     for prod in ${products}; do
-      eups distrib install ${products} -t "${tag}" -vvv
+      eups distrib install "$prod" -t "${tag}" -vvv
     done
 
     if [[ \$FIX_SHEBANGS == true ]]; then


### PR DESCRIPTION
Errantly, the groovy product list was being interpolated inside of the
`eups distrib` loop(s).  This was causing `eups distrib` to fail as it
can not handle multiple products at once.