### PR TITLE
do not require NO_PUSH param

### DIFF
--- a/pipelines/sqre/validate_drp.groovy
+++ b/pipelines/sqre/validate_drp.groovy
@@ -26,7 +26,6 @@ notify.wrap {
     'EUPS_TAG',
     'BUILD_ID',
     'TIMEOUT',
-    'NO_PUSH',
   ]
 
   util.requireParams(required)


### PR DESCRIPTION
This is a boolean value and current required logic is testing it for
truthiness, which obviously will fail when this value is legitimately
false (which is the case when triggered by a release pipeline in the
production env).