### PR TITLE
rm NO_FETCH param from stack-os-matrix

### DIFF
--- a/jobs/stack_os_matrix.groovy
+++ b/jobs/stack_os_matrix.groovy
@@ -8,7 +8,8 @@ pipelineJob("stack-os-matrix") {
     stringParam('BRANCH', null, 'Whitespace delimited list of "refs" to attempt to build.  Priority is highest -> lowest from left to right.  "master" is implicitly appended to the right side of the list, if not specified.')
     stringParam('PRODUCT', 'lsst_distrib', 'Whitespace delimited list of EUPS products to build.')
     booleanParam('SKIP_DEMO', false, 'Do not run the demo after all packages have completed building.')
-    booleanParam('NO_FETCH', false, 'Do not pull from git remote if branch is already the current ref. (This should generally be false outside of testing the CI system)')
+    // XXX testing only
+    //booleanParam('NO_FETCH', false, 'Do not pull from git remote if branch is already the current ref. (This should generally be false outside of testing the CI system)')
   }
 
   properties {


### PR DESCRIPTION
This parameter is only useful when testing the ci system.