### PR TITLE
wipeout workspace at start of build

### DIFF
--- a/pipelines/release/nightly_release.groovy
+++ b/pipelines/release/nightly_release.groovy
@@ -201,6 +201,7 @@ notify.wrap {
               string(name: 'EUPS_TAG', value: eupsTag),
               string(name: 'BUILD_ID', value: bx),
               booleanParam(name: 'NO_PUSH', value: false),
+              booleanParam(name: 'WIPEOUT', value: true),
             ],
             wait: false
         }

--- a/pipelines/release/weekly_release.groovy
+++ b/pipelines/release/weekly_release.groovy
@@ -212,6 +212,7 @@ notify.wrap {
               string(name: 'EUPS_TAG', value: eupsTag),
               string(name: 'BUILD_ID', value: bx),
               booleanParam(name: 'NO_PUSH', value: false),
+              booleanParam(name: 'WIPEOUT', value: true),
             ],
             wait: false
         }


### PR DESCRIPTION
This is an attempt to reduce the frequency at which the hsc dataset
fills up the disk.