### PR TITLE
pin matrix builds to osx-10.12

### DIFF
--- a/etc/science_pipelines/build_matrix.yaml
+++ b/etc/science_pipelines/build_matrix.yaml
@@ -39,6 +39,8 @@ matrix:
   - <<: *el7-py2
   - <<: *el7-py3
   - <<: *osx-py3
+    label: osx-10.12
+    compiler: clang-802.0.42
 tarball:
   - <<: *tarball_defaults
     <<: *el6-py2


### PR DESCRIPTION
This is to prevent the compiler string from not matching between
osx-10.11 and osx-10.12.