### PR TITLE
silence NPE error on cron triggered builds

### DIFF
--- a/pipelines/lib/notify.groovy
+++ b/pipelines/lib/notify.groovy
@@ -20,7 +20,7 @@ String duration() {
 // a workspace / shell env vars being setup; this seems unnecessarily difficult
 // but it saves the overhead and latency of using a node block.
 String jenkinsUserId() {
-  currentBuild.build().getCause(Cause.UserIdCause).getUserId()
+  currentBuild.build().getCause(Cause.UserIdCause)?.getUserId()
 }
 
 Map githubToSlack(String user) {


### PR DESCRIPTION
When Cause.UserIdCause is null, this (non-fatal) error message is being
displayed in the build console:

    java.lang.NullPointerException: Cannot invoke method getUserId() on null object