### PR TITLE
wipeout tarball workspace between builds

### DIFF
--- a/pipelines/lib/util.groovy
+++ b/pipelines/lib/util.groovy
@@ -638,6 +638,7 @@ def void buildTarballMatrix(
             booleanParam(name: 'RUN_DEMO', value: opt.RUN_DEMO),
             booleanParam(name: 'RUN_SCONS_CHECK', value: opt.RUN_SCONS_CHECK),
             booleanParam(name: 'PUBLISH', value: opt.PUBLISH),
+            booleanParam(name: 'WIPEOUT', value: true),
             string(name: 'TIMEOUT', value: '6'), // hours
             string(name: 'IMAGE', value: nullToEmpty(item.image)),
             string(name: 'LABEL', value: item.label),


### PR DESCRIPTION
This is intended as a short term work around for eups distrib tags being
[re]pushed from previous builds.