### PR TITLE
change node cleanup frequency to 10mins

### DIFF
--- a/jobs/node_cleanup.groovy
+++ b/jobs/node_cleanup.groovy
@@ -7,7 +7,7 @@ job('sqre/infrastructure/jenkins-node-cleanup') {
   concurrentBuild(false)
 
   triggers {
-    cron('H/30 * * * *')
+    cron('H/10 * * * *')
   }
 
   wrappers {


### PR DESCRIPTION
The build times for cleanup seem to generally be < 5mins and a noop is < 1s.  The load increase from running more frequently is very low and will reduce the idle time of nodes waiting for cleanup.