### PR TITLE
only run build on jenkins master node

### DIFF
--- a/pipelines/sqre/backup/jenkins_ebs_snapshot.groovy
+++ b/pipelines/sqre/backup/jenkins_ebs_snapshot.groovy
@@ -36,7 +36,7 @@ notify.wrap {
     } // withCredentials
   } // run
 
-  node('docker') {
+  node('jenkins-master') {
     timeout(time: 1, unit: 'HOURS') {
       run()
     }


### PR DESCRIPTION
This is required as the ec2 instance ID is fetched from the the metadata
service.