### PR TITLE
bump awscli version to 1.14.61

### DIFF
--- a/jobs/build_awscli.groovy
+++ b/jobs/build_awscli.groovy
@@ -5,7 +5,7 @@ p.pipeline().with {
   description('Constructs docker awscli images.')
 
   parameters {
-    stringParam('AWSCLI_VER', '1.14.2', 'awscli version to install')
+    stringParam('AWSCLI_VER', '1.14.61', 'awscli version to install')
     booleanParam('NO_PUSH', false, 'Do not push image to docker registry.')
     booleanParam('LATEST', false, 'Also push to docker registry with "latest" tag.')
   }


### PR DESCRIPTION
To pickup working aws ec2 create-snapshot --tag-specifications.