### PR TITLE
remove python 2.x support

### DIFF
--- a/etc/science_pipelines/build_matrix.yaml
+++ b/etc/science_pipelines/build_matrix.yaml
@@ -52,19 +52,12 @@ canonical:
   <<: *el7-py3
 tarball:
   - <<: *tarball_defaults
-    <<: *el6-py2
-  - <<: *tarball_defaults
     <<: *el6-py3
-  - <<: *tarball_defaults
-    <<: *el7-py2
   - <<: *tarball_defaults
     <<: *el7-py3
   # need newinstall.sh support for devtoolset-7
   # - <<: *tarball_defaults
   #  <<: *el7-dts7-py3
-  - <<: *tarball_defaults
-    <<: *osx-py2
-    label: osx-10.11
   - <<: *tarball_defaults
     <<: *osx-py3
     label: osx-10.11

--- a/etc/science_pipelines/build_matrix.yaml
+++ b/etc/science_pipelines/build_matrix.yaml
@@ -42,7 +42,6 @@ template:
       python: '3'
 matrix:
   - <<: *el6-py3
-  - <<: *el7-py2
   - <<: *el7-py3
   - <<: *osx-py3
     label: osx-10.11||osx-10.12

--- a/etc/science_pipelines/build_matrix.yaml
+++ b/etc/science_pipelines/build_matrix.yaml
@@ -5,21 +5,11 @@ template:
     lsstsw_ref: '10a4fa6'
   linux_compiler: &linux_compiler devtoolset-6
   platforms:
-    - &el6-py2
-      image: docker.io/lsstsqre/centos:6-stackbase-devtoolset-6
-      label: centos-6
-      compiler: *linux_compiler
-      python: '2'
     - &el6-py3
       image: docker.io/lsstsqre/centos:6-stackbase-devtoolset-6
       label: centos-6
       compiler: *linux_compiler
       python: '3'
-    - &el7-py2
-      image: docker.io/lsstsqre/centos:7-stackbase-devtoolset-6
-      label: centos-7
-      compiler: *linux_compiler
-      python: '2'
     - &el7-py3
       image: docker.io/lsstsqre/centos:7-stackbase-devtoolset-6
       label: centos-7
@@ -30,11 +20,6 @@ template:
       label: centos-7
       compiler: devtoolset-7
       python: '3'
-    - &osx-py2
-      image: null
-      label: osx
-      compiler: clang-800.0.42.1
-      python: '2'
     - &osx-py3
       image: null
       label: osx


### PR DESCRIPTION
DM science pipelines has dropped support for py2 after the v15 release.