### PR TITLE
disable weekly backups of eups pkgroot(s)

### DIFF
--- a/jobs/s3backup_eups.groovy
+++ b/jobs/s3backup_eups.groovy
@@ -2,7 +2,7 @@ import util.Plumber
 
 [
   DAILY:   'H 4 * * *',
-  WEEKLY:  'H 4 * * 0',
+//  WEEKLY:  'H 4 * * 0',
   MONTHLY: 'H 4 1 * *',
 ].each { type, crontab ->
   def p = new Plumber(


### PR DESCRIPTION
This is soley to reduce ammount of backup data being stored on s3.