### PR TITLE
split science-pipelines/ci_hsc out of science-pipelines/lsst_distrib

### DIFF
--- a/etc/science_pipelines/build_matrix.yaml
+++ b/etc/science_pipelines/build_matrix.yaml
@@ -39,6 +39,8 @@ scipipe-lsstsw-matrix:
     # allow 800.0.42 and 800.0.42.1
     compiler: ^clang-802.0.42$ ^clang-800.0.42.1$
     display_compiler: clang
+scipipe-lsstsw-ci_hsc:
+  - <<: *el7-py3
 dax-lsstsw-matrix:
   - <<: *el7-py3
   - <<: *el7-py3-llvm

--- a/jobs/clean_builds.groovy
+++ b/jobs/clean_builds.groovy
@@ -6,9 +6,17 @@ import util.CleanBuild
 [
   [
     name: 'science-pipelines/lsst_distrib',
-    product: 'lsst_distrib ci_hsc',
+    product: 'lsst_distrib',
     skipDemo: false,
     skipDocs: false,
+    seedJob: SEED_JOB,
+  ],
+  [
+    name: 'science-pipelines/ci_hsc',
+    product: 'ci_hsc',
+    skipDemo: true,
+    skipDocs: true,
+    buildConfig: 'scipipe-lsstsw-ci_hsc',
     seedJob: SEED_JOB,
   ],
   [


### PR DESCRIPTION
This is so failures of`ci_hsc` on master do not cause the clean build of
`lsst_distrib` to fail, as this is used as a canary for "releasablity" of
`lsst_distrib`.