### PR TITLE
bump codekit to 7.2.0

### DIFF
--- a/etc/sqre/config.yaml
+++ b/etc/sqre/config.yaml
@@ -14,7 +14,7 @@ awscli:
     tag: *awscli_ver
 codekit:
   pypi:
-    version: &codekit_ver '7.1.0'
+    version: &codekit_ver '7.2.0'
   dockerfile:
     github_repo: lsst-sqre/sqre-codekit
     git_ref: master


### PR DESCRIPTION
To pickup `github-tag-release --manifest-only`.