### PR TITLE
consistently use gitRef instead of githubRef

### DIFF
--- a/pipelines/release/docker/build_stack.groovy
+++ b/pipelines/release/docker/build_stack.groovy
@@ -32,7 +32,7 @@ notify.wrap {
   def newinstall     = config.newinstall
 
   def githubRepo     = util.githubSlugToUrl(dockerfile.github_repo)
-  def githubRef      = dockerfile.git_ref
+  def gitRef         = dockerfile.git_ref
   def buildDir       = dockerfile.dir
   def dockerRepo     = dockerRegistry.repo
   def dockerTag      = "7-stack-lsst_distrib-${eupsTag}"
@@ -50,7 +50,7 @@ notify.wrap {
     stage('checkout') {
       repo = git([
         url: githubRepo,
-        branch: githubRef,
+        branch: gitRef,
       ])
     }
 

--- a/pipelines/sqre/backup/build_ec2_snapshot.groovy
+++ b/pipelines/sqre/backup/build_ec2_snapshot.groovy
@@ -24,8 +24,8 @@ notify.wrap {
   def hubRepo    = 'lsstsqre/ec2-snapshot'
   def githubSlug = 'lsst-sqre/ec2-snapshot'
   def githubRepo = "https://github.com/${githubSlug}"
-  def githubRef  = 'master'
-  def dockerTag  = util.sanitizeDockerTag(githubRef)
+  def gitRef     = 'master'
+  def dockerTag  = util.sanitizeDockerTag(gitRef)
   def dockerDir  = '.'
 
   def image = null
@@ -36,7 +36,7 @@ notify.wrap {
     stage('checkout') {
       git([
         url: githubRepo,
-        branch: githubRef,
+        branch: gitRef,
       ])
 
       abbrHash = sh(returnStdout: true, script: "git log -n 1 --pretty=format:'%h'").trim()
@@ -56,7 +56,7 @@ notify.wrap {
           'dockerhub-sqreadmin'
         ) {
           image.push(dockerTag)
-          if (githubRef == 'master') {
+          if (gitRef == 'master') {
             image.push("g${abbrHash}")
           }
           if (pushLatest) {

--- a/pipelines/sqre/backup/build_sqre_github_snapshot.groovy
+++ b/pipelines/sqre/backup/build_sqre_github_snapshot.groovy
@@ -23,8 +23,8 @@ notify.wrap {
 
   def hubRepo    = 'lsstsqre/sqre-github-snapshot'
   def githubRepo = 'lsst-sqre/sqre-git-snapshot'
-  def githubRef  = 'refs/tags/0.2.1'
-  def hubTag     = tagBasename(githubRef)
+  def gitRef     = 'refs/tags/0.2.1'
+  def hubTag     = tagBasename(gitRef)
 
   def image = null
 
@@ -35,7 +35,7 @@ notify.wrap {
       checkout([
         $class: 'GitSCM',
         userRemoteConfigs: [[url: "https://github.com/${githubRepo}"]],
-        branches: [[name: githubRef]],
+        branches: [[name: gitRef]],
         poll: false
       ])
 

--- a/pipelines/sqre/infrastructure/build_awscli.groovy
+++ b/pipelines/sqre/infrastructure/build_awscli.groovy
@@ -29,7 +29,7 @@ notify.wrap {
   def dockerRegistry  = awscli.docker_registry
 
   def githubRepo = util.githubSlugToUrl(dockerfile.github_repo)
-  def githubRef  = dockerfile.git_ref
+  def gitRef     = dockerfile.git_ref
   def buildDir   = dockerfile.dir
   def dockerRepo = dockerRegistry.repo
 

--- a/pipelines/sqre/infrastructure/build_codekit.groovy
+++ b/pipelines/sqre/infrastructure/build_codekit.groovy
@@ -29,7 +29,7 @@ notify.wrap {
   def dockerRegistry = codekit.docker_registry
 
   def githubRepo = util.githubSlugToUrl(dockerfile.github_repo)
-  def githubRef  = dockerfile.git_ref
+  def gitRef     = dockerfile.git_ref
   def buildDir   = dockerfile.dir
   def dockerRepo = dockerRegistry.repo
 

--- a/pipelines/sqre/infrastructure/build_documenteer_base.groovy
+++ b/pipelines/sqre/infrastructure/build_documenteer_base.groovy
@@ -24,7 +24,7 @@ notify.wrap {
   def hubRepo    = 'lsstsqre/documenteer-base'
   def githubSlug = 'lsst-sqre/docker-documenteer-base'
   def githubRepo = "https://github.com/${githubSlug}"
-  def githubRef  = 'master'
+  def gitRef     = 'master'
   def dockerDir  = ''
 
   def image = null
@@ -35,7 +35,7 @@ notify.wrap {
     stage('checkout') {
       git([
         url: githubRepo,
-        branch: githubRef,
+        branch: gitRef,
       ])
 
       abbrHash = sh(returnStdout: true, script: "git log -n 1 --pretty=format:'%h'").trim()
@@ -58,8 +58,8 @@ notify.wrap {
           'https://index.docker.io/v1/',
           'dockerhub-sqreadmin'
         ) {
-          image.push(githubRef)
-          if (githubRef == 'master') {
+          image.push(gitRef)
+          if (gitRef == 'master') {
             image.push("g${abbrHash}")
           }
           if (pushLatest) {

--- a/pipelines/sqre/infrastructure/build_eupsredirector.groovy
+++ b/pipelines/sqre/infrastructure/build_eupsredirector.groovy
@@ -24,7 +24,7 @@ notify.wrap {
   def hubRepo    = 'lsstsqre/eupsredirector'
   def githubSlug = 'lsst-sqre/deploy-pkgroot-redirect'
   def githubRepo = "https://github.com/${githubSlug}"
-  def githubRef  = 'master'
+  def gitRef     = 'master'
   def dockerDir  = 'eupsredirector'
 
   def image = null
@@ -35,7 +35,7 @@ notify.wrap {
     stage('checkout') {
       git([
         url: githubRepo,
-        branch: githubRef,
+        branch: gitRef,
       ])
 
       abbrHash = sh(returnStdout: true, script: "git log -n 1 --pretty=format:'%h'").trim()
@@ -55,8 +55,8 @@ notify.wrap {
           'https://index.docker.io/v1/',
           'dockerhub-sqreadmin'
         ) {
-          image.push(githubRef)
-          if (githubRef == 'master') {
+          image.push(gitRef)
+          if (gitRef == 'master') {
             image.push("g${abbrHash}")
           }
           if (pushLatest) {

--- a/pipelines/sqre/infrastructure/build_gitlfs.groovy
+++ b/pipelines/sqre/infrastructure/build_gitlfs.groovy
@@ -25,7 +25,7 @@ notify.wrap {
 
   def hubRepo    = 'lsstsqre/gitlfs'
   def githubRepo = 'lsst-sqre/docker-gitlfs'
-  def githubRef  = 'master'
+  def gitRef     = 'master'
 
   def image = null
 
@@ -33,7 +33,7 @@ notify.wrap {
     stage('checkout') {
       git([
         url: "https://github.com/${githubRepo}",
-        branch: githubRef,
+        branch: gitRef,
       ])
     }
 

--- a/pipelines/sqre/infrastructure/build_gitlfs_server.groovy
+++ b/pipelines/sqre/infrastructure/build_gitlfs_server.groovy
@@ -24,7 +24,7 @@ notify.wrap {
   def hubRepo    = 'lsstsqre/gitlfs-server'
   def githubSlug = 'lsst-sqre/git-lfs-s3-server'
   def githubRepo = "https://github.com/${githubSlug}"
-  def githubRef  = 'master'
+  def gitRef     = 'master'
   def dockerDir  = 'docker'
 
   def image = null
@@ -35,7 +35,7 @@ notify.wrap {
     stage('checkout') {
       git([
         url: githubRepo,
-        branch: githubRef,
+        branch: gitRef,
       ])
 
       abbrHash = sh(returnStdout: true, script: "git log -n 1 --pretty=format:'%h'").trim()
@@ -44,7 +44,7 @@ notify.wrap {
     stage('build') {
       dir(dockerDir) {
         // ensure base image is always up to date
-        image = docker.build("${hubRepo}", "--pull=true --no-cache --build-arg REPO=${githubRepo} --build-arg REF=${githubRef} .")
+        image = docker.build("${hubRepo}", "--pull=true --no-cache --build-arg REPO=${githubRepo} --build-arg REF=${gitRef} .")
       }
     }
 
@@ -54,8 +54,8 @@ notify.wrap {
           'https://index.docker.io/v1/',
           'dockerhub-sqreadmin'
         ) {
-          image.push(githubRef)
-          if (githubRef == 'master') {
+          image.push(gitRef)
+          if (gitRef == 'master') {
             image.push("g${abbrHash}")
           }
           if (pushLatest) {

--- a/pipelines/sqre/infrastructure/build_ltd_mason.groovy
+++ b/pipelines/sqre/infrastructure/build_ltd_mason.groovy
@@ -25,7 +25,7 @@ notify.wrap {
 
   def hubRepo    = 'lsstsqre/ltd-mason'
   def githubRepo = 'lsst-sqre/ltd-mason'
-  def githubRef  = 'master'
+  def gitRef     = 'master'
   def buildDir   = 'docker'
 
   def image = null
@@ -34,7 +34,7 @@ notify.wrap {
     stage('checkout') {
       git([
         url: "https://github.com/${githubRepo}",
-        branch: githubRef,
+        branch: gitRef,
       ])
     }
 

--- a/pipelines/sqre/infrastructure/build_newinstall.groovy
+++ b/pipelines/sqre/infrastructure/build_newinstall.groovy
@@ -27,7 +27,7 @@ notify.wrap {
   def dockerRegistry = newinstall.docker_registry
 
   def githubRepo    = util.githubSlugToUrl(dockerfile.github_repo)
-  def githubRef     = dockerfile.git_ref
+  def gitRef        = dockerfile.git_ref
   def buildDir      = dockerfile.dir
   def dockerRepo    = dockerRegistry.repo
   def newinstallUrl = util.newinstallUrl()
@@ -40,7 +40,7 @@ notify.wrap {
     stage('checkout') {
       git([
         url: githubRepo,
-        branch: githubRef,
+        branch: gitRef,
       ])
 
       abbrHash = sh(returnStdout: true, script: "git log -n 1 --pretty=format:'%h'").trim()
@@ -73,8 +73,8 @@ notify.wrap {
           'https://index.docker.io/v1/',
           'dockerhub-sqreadmin'
         ) {
-          image.push(util.sanitizeDockerTag(githubRef))
-          if (githubRef == 'master') {
+          image.push(util.sanitizeDockerTag(gitRef))
+          if (gitRef == 'master') {
             image.push("g${abbrHash}")
           }
           if (pushLatest) {

--- a/pipelines/sqre/infrastructure/build_postqa.groovy
+++ b/pipelines/sqre/infrastructure/build_postqa.groovy
@@ -23,7 +23,7 @@ notify.wrap {
 
   def hubRepo    = 'lsstsqre/postqa'
   def githubRepo = 'lsst-sqre/docker-postqa'
-  def githubRef  = 'master'
+  def gitRef     = 'master'
   def postqaVer  = '1.3.3'
 
   def image = null
@@ -32,7 +32,7 @@ notify.wrap {
     stage('checkout') {
       git([
         url: "https://github.com/${githubRepo}",
-        branch: githubRef,
+        branch: gitRef,
       ])
     }
 

--- a/pipelines/sqre/infrastructure/build_s3cmd.groovy
+++ b/pipelines/sqre/infrastructure/build_s3cmd.groovy
@@ -25,7 +25,7 @@ notify.wrap {
 
   def hubRepo    = 'lsstsqre/s3cmd'
   def githubRepo = 'lsst-sqre/docker-s3cmd'
-  def githubRef  = 'master'
+  def gitRef     = 'master'
 
   def image = null
 
@@ -33,7 +33,7 @@ notify.wrap {
     stage('checkout') {
       git([
         url: "https://github.com/${githubRepo}",
-        branch: githubRef,
+        branch: gitRef,
       ])
     }
 

--- a/pipelines/sqre/infrastructure/build_tag_monger.groovy
+++ b/pipelines/sqre/infrastructure/build_tag_monger.groovy
@@ -24,7 +24,7 @@ notify.wrap {
   def hubRepo    = 'lsstsqre/tag-monger'
   def githubSlug = 'lsst-sqre/tag-monger'
   def githubRepo = "https://github.com/${githubSlug}"
-  def githubRef  = 'master'
+  def gitRef     = 'master'
   def dockerDir  = ''
 
   def image = null
@@ -35,7 +35,7 @@ notify.wrap {
     stage('checkout') {
       git([
         url: githubRepo,
-        branch: githubRef,
+        branch: gitRef,
       ])
 
       abbrHash = sh(returnStdout: true, script: "git log -n 1 --pretty=format:'%h'").trim()
@@ -58,8 +58,8 @@ notify.wrap {
           'https://index.docker.io/v1/',
           'dockerhub-sqreadmin'
         ) {
-          image.push(githubRef)
-          if (githubRef == 'master') {
+          image.push(gitRef)
+          if (gitRef == 'master') {
             image.push("g${abbrHash}")
           }
           if (pushLatest) {

--- a/pipelines/sqre/infrastructure/build_wget.groovy
+++ b/pipelines/sqre/infrastructure/build_wget.groovy
@@ -23,7 +23,7 @@ notify.wrap {
 
   def hubRepo    = 'lsstsqre/wget'
   def githubRepo = 'lsst-sqre/docker-wget'
-  def githubRef  = 'master'
+  def gitRef     = 'master'
 
   def image = null
 
@@ -31,7 +31,7 @@ notify.wrap {
     stage('checkout') {
       git([
         url: "https://github.com/${githubRepo}",
-        branch: githubRef,
+        branch: gitRef,
       ])
     }
 
@@ -46,7 +46,7 @@ notify.wrap {
           'https://index.docker.io/v1/',
           'dockerhub-sqreadmin'
         ) {
-          image.push(githubRef)
+          image.push(gitRef)
           if (pushLatest) {
             image.push('latest')
           }


### PR DESCRIPTION
To avoid confusion with the naming convention used in the yaml config
files.