### PR TITLE
disable github-tag-teams

### DIFF
--- a/pipelines/release/official_release.groovy
+++ b/pipelines/release/official_release.groovy
@@ -70,6 +70,7 @@ notify.wrap {
       } // retry
     } // stage
 
+    /*
     // add aux repo tags *after* tagging eups product repos so as to avoid a
     // trainwreck if an aux repo has been pulled into the build (without
     // first being removed from the aux team).
@@ -86,6 +87,7 @@ notify.wrap {
         } // node
       } // retry
     } // stage
+    */
 
     stage('build') {
       retry(retries) {


### PR DESCRIPTION
Until support for ignoring existing tags can be merged.