### PR TITLE
    bump miniconda to 4.5.4

### DIFF
--- a/etc/scipipe/build_matrix.yaml
+++ b/etc/scipipe/build_matrix.yaml
@@ -6,7 +6,7 @@
 #
 template:
   tarball_defaults: &tarball_defaults
-    miniver: &miniver '4.3.21'
+    miniver: &miniver '4.5.4'
     lsstsw_ref: '10a4fa6'
     timelimit: 6
   linux_compiler: &linux_compiler devtoolset-6

--- a/jobs/tarball.groovy
+++ b/jobs/tarball.groovy
@@ -17,7 +17,7 @@ p.pipeline().with {
     choiceParam('LABEL', ['centos-7', 'centos-6', 'osx-10.11'], 'LSST conda package set ref')
     stringParam('COMPILER', null, 'compiler version string')
     choiceParam('PYTHON_VERSION', ['3', '2'], 'Python major version')
-    choiceParam('MINIVER', ['4.3.21', '4.2.12'], 'Miniconda installer version')
+    choiceParam('MINIVER', ['4.5.4', '4.3.21', '4.2.12'], 'Miniconda installer version')
     choiceParam('LSSTSW_REF', ['10a4fa6', '7c8e67'], 'LSST conda package set ref')
     choiceParam('OSFAMILY', ['redhat', 'osx'], 'Published osfamily name')
     stringParam('PLATFORM', null, 'Published platform name')


### PR DESCRIPTION
A, presumably non-repeatable, s3 failure was observed while pulling the
wget docker image.

    error pulling image configuration: Get https://docker-images-prod.s3.amazonaws.com/registry-v2/docker/registry/v2/blobs/sha256/9a/9a1be40498ac989df1a5c1af81caaf06968968371eecdcf822fafb3fe21bf0c0/data?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAIQF2R62EC73X2HOA%2F20180708%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20180708T190324Z&X-Amz-Expires=1200&X-Amz-SignedHeaders=host&X-Amz-Signature=c5ac3dab196ce7f689840db2d6ae4a021ec3acb0285cef96b8d5b961395c1c71: dial tcp 52.216.65.104:443: i/o timeout