### PR TITLE
re-enable osx tarball builds

### DIFF
--- a/etc/scipipe/build_matrix.yaml
+++ b/etc/scipipe/build_matrix.yaml
@@ -65,15 +65,13 @@ tarball:
   # need newinstall.sh support for devtoolset-7
   # - <<: *tarball_defaults
   #  <<: *el7-dts7-py3
-  # XXX osx tarball builds are disabled due to `eups distrib install`
-  # consistently hanging starting on 2018-07-29
-  #- <<: *tarball_defaults
-  #  <<: *osx-py3
-  #  label: osx-10.11
-  #  platform: '10.9'
-  #  osfamily: osx
-  #  timelimit: 8
-  #  allow_fail: true
+  - <<: *tarball_defaults
+    <<: *osx-py3
+    label: osx-10.11
+    platform: '10.9'
+    osfamily: osx
+    timelimit: 8
+    allow_fail: true
 #
 # canonical build env -- Ie., release/{run-rebuild,run-publish}
 #


### PR DESCRIPTION
This reverts commit 3ff61df48ec217a7f7cbc7aaedb0335364d1a985, reversing
changes made to 311af085130ae811e48320439ebfe04febb0d8a2.