### PR TITLE
fix printing of expection

### DIFF
--- a/jobs/tarball.groovy
+++ b/jobs/tarball.groovy
@@ -14,7 +14,7 @@ p.pipeline().with {
     booleanParam('WIPEOUT', false, 'Completely wipe out workspace(s) before starting build.')
     stringParam('TIMEOUT', '8', 'build timeout in hours')
     stringParam('IMAGE', null, 'published EUPS tag')
-    choiceParam('LABEL', ['centos-7', 'centos-6', 'osx-10.11'], 'Jenkins build agent label')
+    choiceParam('LABEL', ['centos-7', 'centos-6', 'osx-10.11', 'osx-10.12'], 'Jenkins build agent label')
     stringParam('COMPILER', null, 'compiler version string')
     choiceParam('PYTHON_VERSION', ['3', '2'], 'Python major version')
     choiceParam('MINIVER', ['4.5.4', '4.3.21', '4.2.12'], 'Miniconda installer version')

--- a/jobs/tarball.groovy
+++ b/jobs/tarball.groovy
@@ -14,7 +14,7 @@ p.pipeline().with {
     booleanParam('WIPEOUT', false, 'Completely wipe out workspace(s) before starting build.')
     stringParam('TIMEOUT', '8', 'build timeout in hours')
     stringParam('IMAGE', null, 'published EUPS tag')
-    choiceParam('LABEL', ['centos-7', 'centos-6', 'osx-10.11'], 'LSST conda package set ref')
+    choiceParam('LABEL', ['centos-7', 'centos-6', 'osx-10.11'], 'Jenkins build agent label')
     stringParam('COMPILER', null, 'compiler version string')
     choiceParam('PYTHON_VERSION', ['3', '2'], 'Python major version')
     choiceParam('MINIVER', ['4.5.4', '4.3.21', '4.2.12'], 'Miniconda installer version')

--- a/pipelines/lib/util.groovy
+++ b/pipelines/lib/util.groovy
@@ -1038,7 +1038,7 @@ def void buildTarballMatrix(Map p) {
           tarballBuild()
         } catch (e) {
           echo "giving up on build but suppressing error"
-          echo e
+          echo e.toString()
         }
       } else {
         tarballBuild()


### PR DESCRIPTION
Attempt to resolve this error message:

    Could not instantiate {message=hudson.AbortException: release » tarball #3217 completed with status FAILURE (propagate: false to ignore)} for EchoStep(message: String): java.lang.ClassCastException: org.jenkinsci.plugins.workflow.steps.EchoStep.message expects class java.lang.String but received class hudson.AbortException