### PR TITLE
drop osx 10.11; switch to using 10.12 for all builds

### DIFF
--- a/etc/scipipe/build_matrix.yaml
+++ b/etc/scipipe/build_matrix.yaml
@@ -33,8 +33,8 @@ template:
       python: '3'
     - &osx-py3
       image: null
-      label: osx
-      compiler: clang-800.0.42.1
+      label: osx-10.12
+      compiler: clang-802.0.42
       python: '3'
 #
 # build environemnt/matrix configs
@@ -43,10 +43,9 @@ scipipe-lsstsw-matrix:
   - <<: *el6-py3
   - <<: *el7-py3
   - <<: *osx-py3
-    label: osx-10.11||osx-10.12
+    #label: osx-10.11||osx-10.12
     display_name: osx
-    # allow 800.0.42 and 800.0.42.1
-    compiler: ^clang-802.0.42$ ^clang-800.0.42.1$
+    #compiler: ^clang-802.0.42$ ^clang-800.0.42.1$
     display_compiler: clang
 scipipe-lsstsw-ci_hsc:
   - <<: *el7-py3
@@ -67,7 +66,6 @@ tarball:
   #  <<: *el7-dts7-py3
   - <<: *tarball_defaults
     <<: *osx-py3
-    label: osx-10.11
     platform: '10.9'
     osfamily: osx
     timelimit: 8


### PR DESCRIPTION
The build of astshim is failing on 10.11 for some reason -- as we should
have already dropped 10.11 when 10.13 was released, it seems easier to
switch to 10.12 rather than debugging an unsupported version.