### PR TITLE
rm usage of label on pipeline jobs

### DIFF
--- a/jobs/util/CleanBuild.groovy
+++ b/jobs/util/CleanBuild.groovy
@@ -25,7 +25,6 @@ class CleanBuild {
         }
       }
 
-      label('jenkins-master')
       keepDependencies()
 
       if (cron) {

--- a/jobs/util/Plumber.groovy
+++ b/jobs/util/Plumber.groovy
@@ -20,7 +20,6 @@ class Plumber {
     Common.makeFolders(dsl)
 
     dsl.pipelineJob(name) {
-      label('jenkins-master')
       keepDependencies()
       concurrentBuild(false)
 


### PR DESCRIPTION
Per:

    Warning: (Plumber.groovy, line 23) label is deprecated