### PR TITLE
DM-16835: Expand time limit for more metric files.

### DIFF
--- a/etc/scipipe/ap_verify.yaml
+++ b/etc/scipipe/ap_verify.yaml
@@ -20,5 +20,5 @@ ap_verify:
   configs:
     - dataset:
         <<: *dataset_hits2015
-      # squash may take 10+ mins per metric upload (x6)
-      run_timelimit: 90
+      # squash may take 10+ mins per metric upload (x7-12)
+      run_timelimit: 150


### PR DESCRIPTION
This PR increases the `ap_verify` time limit even further to compensate for additional metrics files being introduced by infrastructure changes.