### PR TITLE
use github-api-token-sqreadmin credentials

### DIFF
--- a/pipelines/sqre/infra/travissync.groovy
+++ b/pipelines/sqre/infra/travissync.groovy
@@ -33,7 +33,7 @@ def void doTravissync() {
 
     withCredentials([[
       $class: 'StringBinding',
-      credentialsId: 'github-api-token-sqrbot',
+      credentialsId: 'github-api-token-sqreadmin',
       variable: 'GITHUB_TOKEN'
     ]]) {
       image.inside {


### PR DESCRIPTION
instead of github-api-token-sqrbot, which allows github-api-token-sqrbot
credentials to be retired.