### PR TITLE
set LSST_SPLENV_REF for all uses of lsstsw/newinstall.sh

### DIFF
--- a/etc/scipipe/build_matrix.yaml
+++ b/etc/scipipe/build_matrix.yaml
@@ -5,33 +5,40 @@
 # provide yaml anchors internal to this file.
 #
 template:
+  splenv_ref: &splenv_ref 'fcd27eb'
   tarball_defaults: &tarball_defaults
     miniver: &miniver '4.5.4'
-    splenv_ref: 'fcd27eb'
     timelimit: 6
   linux_compiler: &linux_compiler devtoolset-6
+  platform_defaults: &platform_defaults
+    splenv_ref: *splenv_ref
   platforms:
     - &el6-py3
+      <<: *platform_defaults
       image: docker.io/lsstsqre/centos:6-stackbase-devtoolset-6
       label: centos-6
       compiler: *linux_compiler
       python: '3'
     - &el7-py3
+      <<: *platform_defaults
       image: docker.io/lsstsqre/centos:7-stackbase-devtoolset-6
       label: centos-7
       compiler: *linux_compiler
       python: '3'
     - &el7-dts7-py3
+      <<: *platform_defaults
       image: docker.io/lsstsqre/centos:7-stackbase-devtoolset-7
       label: centos-7
       compiler: devtoolset-7
       python: '3'
     - &el7-py3-llvm
+      <<: *platform_defaults
       image: docker.io/lsstsqre/centos:7-stackbase-llvm-toolset-7
       label: centos-7
       compiler: llvm-toolset-7
       python: '3'
     - &osx-py3
+      <<: *platform_defaults
       image: null
       label: osx-10.12
       compiler: clang-802.0.42

--- a/pipelines/lib/util.groovy
+++ b/pipelines/lib/util.groovy
@@ -369,8 +369,11 @@ def lsstswBuild(
  *
  * Required keys are listed below. Any additional keys will also be set as env
  * vars.
- * @param buildParams.LSST_REFS String
+ * @param buildParams map
+ * @param buildParams.LSST_COMPILER String
  * @param buildParams.LSST_PRODUCTS String
+ * @param buildParams.LSST_REFS String
+ * @param buildParams.LSST_SPLENV_REF String
  */
 def void jenkinsWrapper(Map buildParams) {
   // minimum set of required keys -- additional are allowed
@@ -378,6 +381,7 @@ def void jenkinsWrapper(Map buildParams) {
     'LSST_COMPILER',
     'LSST_PRODUCTS',
     'LSST_REFS',
+    'LSST_SPLENV_REF',
   ])
   def scipipe = scipipeConfig()
 

--- a/pipelines/lib/util.groovy
+++ b/pipelines/lib/util.groovy
@@ -1982,5 +1982,24 @@ def void createFakeLsstswClone(Map p) {
   downloadRepos(destFile: fakeReposFile)
 } // createFlakeLsstwClone
 
+/**
+ * Validate that a map has the minimum required set of keys for an lsstsw
+ * build env configuration.
+ *
+ * Example:
+ *
+ *     util.validateLsstswConfig(lsstswConfig)
+ *
+ * @param p Map
+ */
+def void validateLsstswConfig(Map conf) {
+  requireMapKeys(conf, [
+    'compiler',
+    'image',
+    'label',
+    'python',
+    'splenv_ref',
+  ])
+}
 
 return this;

--- a/pipelines/release/docker/build_stack.groovy
+++ b/pipelines/release/docker/build_stack.groovy
@@ -45,7 +45,8 @@ notify.wrap {
   def shebangtronUrl = util.shebangtronUrl()
 
   def newinstallImage = newinstall.docker_registry.repo
-  def baseImage       = "${newinstallImage}:${newinstall.docker_registry.tag}"
+  def splenvRef       = scipipe.canonical.lsstsw_config.splenv_ref
+  def baseImage       = "${newinstallImage}:${splenvRef}"
 
   def image = null
   def repo  = null

--- a/pipelines/release/docker/build_stack.groovy
+++ b/pipelines/release/docker/build_stack.groovy
@@ -86,6 +86,7 @@ notify.wrap {
       opt << "--build-arg SHEBANGTRON_URL=\"${shebangtronUrl}\""
       opt << "--build-arg VERSIONDB_MANIFEST_ID=\"${manifestId}\""
       opt << "--build-arg LSST_COMPILER=\"${lsstCompiler}\""
+      opt << "--build-arg LSST_SPLENV_REF=\"${splenvRef}\""
       opt << '.'
 
       dir(buildDir) {

--- a/pipelines/release/run_rebuild.groovy
+++ b/pipelines/release/run_rebuild.groovy
@@ -58,6 +58,7 @@ notify.wrap {
         LSST_PREP_ONLY:      prepOnly,
         LSST_PRODUCTS:       products,
         LSST_PYTHON_VERSION: lsstswConfig.python,
+        LSST_SPLENV_REF:     lsstswConfig.splenv_ref,
         LSST_REFS:           refs,
         VERSIONDB_PUSH:      versiondbPush,
         VERSIONDB_REPO:      versiondbRepo,

--- a/pipelines/sqre/infra/build_newinstall.groovy
+++ b/pipelines/sqre/infra/build_newinstall.groovy
@@ -36,6 +36,7 @@ notify.wrap {
   def baseDockerRepo = sqre.layercake.docker_registry.repo
   def baseDockerTag  = '7-stackbase-devtoolset-6'
   def baseImage      = "${baseDockerRepo}:${baseDockerTag}"
+  def splenvRef      = scipipe.canonical.lsstsw_config.splenv_ref
 
   def image = null
 
@@ -58,6 +59,7 @@ notify.wrap {
       opt << '--no-cache'
       opt << "--build-arg BASE_IMAGE=\"${baseImage}\""
       opt << "--build-arg NEWINSTALL_URL=\"${newinstallUrl}\""
+      opt << "--build-arg LSST_SPLENV_REF=\"${splenvRef}\""
       withCredentials([[
         $class: 'StringBinding',
         credentialsId: 'eups-url',

--- a/pipelines/sqre/infra/build_newinstall.groovy
+++ b/pipelines/sqre/infra/build_newinstall.groovy
@@ -81,9 +81,10 @@ notify.wrap {
           'https://index.docker.io/v1/',
           'dockerhub-sqreadmin'
         ) {
-          image.push(util.sanitizeDockerTag(gitRef))
+          image.push(splenvRef)
+          image.push("${splenvRef}-${util.sanitizeDockerTag(gitRef)}")
           if (gitRef == 'master') {
-            image.push("g${abbrHash}")
+            image.push("${splenvRef}-g${abbrHash}")
           }
           if (pushLatest) {
             image.push('latest')


### PR DESCRIPTION
This avoids any ambiguity as to the LSST_SPLENV_REF used for a build and clears up the ideologically untidy situation of  having a mixed "source of truth" where a jenkins defined env var is used for the tarball builds and relying on the default of lsstsw/newinstall.sh in other contexts.  It also ensures that scipipe release docker images are using the correct conda env enforced by docker image tags.