### PR TITLE
replace brew provided python/pip with docker on osx

### DIFF
--- a/jobs/tarball.groovy
+++ b/jobs/tarball.groovy
@@ -17,7 +17,7 @@ p.pipeline().with {
     booleanParam('WIPEOUT', false, 'Completely wipe out workspace(s) before starting build.')
     stringParam('TIMEOUT', '8', 'build timeout in hours')
     stringParam('IMAGE', null, 'published EUPS tag')
-    choiceParam('LABEL', ['centos-7', 'centos-6', 'osx-10.11', 'osx-10.12'], 'Jenkins build agent label')
+    choiceParam('LABEL', ['centos-7', 'centos-6', 'osx-10.11', 'osx-10.12', 'osx-10.14'], 'Jenkins build agent label')
     stringParam('COMPILER', null, 'compiler version string')
     choiceParam('PYTHON_VERSION', ['3', '2'], 'Python major version')
     choiceParam('MINIVER', ['4.5.12', '4.5.4', '4.3.21', '4.2.12'], 'Miniconda installer version')

--- a/jobs/tarball.groovy
+++ b/jobs/tarball.groovy
@@ -21,7 +21,7 @@ p.pipeline().with {
     stringParam('COMPILER', null, 'compiler version string')
     choiceParam('PYTHON_VERSION', ['3', '2'], 'Python major version')
     choiceParam('MINIVER', ['4.5.12', '4.5.4', '4.3.21', '4.2.12'], 'Miniconda installer version')
-    choiceParam('SPLENV_REF', ['fcd27eb', '10a4fa6', '7c8e67'], 'LSST conda package set ref')
+    choiceParam('SPLENV_REF', ['fcd27eb', '10a4fa6', '7c8e67', '1172c30'], 'LSST conda package set ref')
     choiceParam('OSFAMILY', ['redhat', 'osx'], 'Published osfamily name')
     stringParam('PLATFORM', null, 'Published platform name')
   }

--- a/pipelines/release/tarball.groovy
+++ b/pipelines/release/tarball.groovy
@@ -215,7 +215,7 @@ def void osxTarballs(
 
           stage('publish') {
             if (publish) {
-              s3PushVenv(envId)
+              s3PushDocker(envId)
             }
           }
         } // dir
@@ -596,38 +596,6 @@ def void writeScript(Map p) {
 
   writeFile(file: p.file, text: p.text)
   util.bash "chmod a+x ${p.file}"
-}
-
-/**
- * Push {@code ./distrib} dir to an s3 bucket under the "path" formed by
- * joining the {@code parts} parameters.
- */
-def void s3PushVenv(String ... parts) {
-  def objectPrefix = "stack/" + util.joinPath(parts)
-  def cwd = pwd()
-
-  util.bash """
-    # do not assume virtualenv is present
-    pip install virtualenv
-    virtualenv venv
-    . venv/bin/activate
-    pip install --upgrade pip
-    pip install --upgrade awscli==${sqre.awscli.pypi.version}
-  """
-
-  def env = [
-    "EUPS_PKGROOT=${cwd}/distrib",
-    "EUPS_S3_OBJECT_PREFIX=${objectPrefix}",
-  ]
-
-  withEnv(env) {
-    withEupsBucketEnv {
-      util.bash """
-        . venv/bin/activate
-        ${s3PushCmd()}
-      """
-    } // withEupsBucketEnv
-  } // withEnv
 }
 
 /**


### PR DESCRIPTION
This makes the osx code path more similar to linux by reusing the same utility
method for pushing to s3.