### PR TITLE
Revert "disable osx builds; dns resolution appears broken"

### DIFF
--- a/etc/scipipe/build_matrix.yaml
+++ b/etc/scipipe/build_matrix.yaml
@@ -67,16 +67,16 @@ template:
 scipipe-lsstsw-matrix:
   - <<: *el6-py3
   - <<: *el7-py3
-  #- <<: *high_sierra-py3
-  #  # allow builds on sierra and mojave
-  #  label: osx-10.13||osx-10.14
-  #  display_name: osx
-  #  display_compiler: clang
+  - <<: *high_sierra-py3
+    # allow builds on sierra and mojave
+    label: osx-10.13||osx-10.14
+    display_name: osx
+    display_compiler: clang
 scipipe-lsstsw-lsst_distrib:
   - <<: *el6-py3
   - <<: *el7-py3
-  #- <<: *high_sierra-py3
-  #- <<: *mojave-py3
+  - <<: *high_sierra-py3
+  - <<: *mojave-py3
 scipipe-lsstsw-ci_hsc:
   - <<: *el7-py3
 dax-lsstsw-matrix:


### PR DESCRIPTION
This reverts commit 7435b46b9a73fd36a6e79002b6356461957d6830.