### PR TITLE
disable weekly release job

### DIFF
--- a/jobs/weekly_release.groovy
+++ b/jobs/weekly_release.groovy
@@ -2,6 +2,7 @@ import util.Plumber
 
 def p = new Plumber(name: 'release/weekly-release', dsl: this)
 p.pipeline().with {
+  disabled()
   description('Tag and release the science-pipelines "weekly".')
 
   parameters {

--- a/jobs/weekly_release_cron.groovy
+++ b/jobs/weekly_release_cron.groovy
@@ -2,6 +2,7 @@ import util.Plumber
 
 def p = new Plumber(name: 'release/weekly-release-cron', dsl: this)
 p.pipeline().with {
+  disabled()
   description('Periodically trigger the DM pipelines/dax "weekly".')
 
   triggers {


### PR DESCRIPTION
To prevent _31, which was triggered early, from being stompped on.