### PR TITLE
add allow_fail flag to lsstsw build config map format

### DIFF
--- a/pipelines/lib/util.groovy
+++ b/pipelines/lib/util.groovy
@@ -337,7 +337,15 @@ def lsstswBuild(
             deleteDir()
           }
 
-          doRun()
+          try {
+            doRun()
+          } catch (e) {
+            if (!lsstswConfig.allow_fail) {
+              throw e
+            }
+            echo "giving up on build but suppressing error"
+            echo e.toString()
+          } // try
         } // dir
       } finally {
         // needs to be called in the parent dir of jenkinsWrapper() in order to


### PR DESCRIPTION
To be consistent with the allow_fail flag used for tarball build config.