### PR TITLE
disable stack-os-matrix el6 builds

### DIFF
--- a/etc/scipipe/build_matrix.yaml
+++ b/etc/scipipe/build_matrix.yaml
@@ -71,12 +71,12 @@ template:
 # build environment/matrix configs
 #
 scipipe-lsstsw-matrix:
-  - <<: *el6-py3
+#  - <<: *el6-py3
   - <<: *el7-py3
   - <<: *el7-dts8-py3
     allow_fail: true
-  - <<: *el6-dts8-py3
-    allow_fail: true
+#  - <<: *el6-dts8-py3
+#    allow_fail: true
   - <<: *high_sierra-py3
     # allow builds on sierra and mojave
     label: osx-10.13||osx-10.14


### PR DESCRIPTION
The increased matrix size of having devtoolset-6 and -8 both building during
the transition period from -6 -> -8 is causing larger than normal backlogs.
The intent is to disable el6 (-6 & -8) until devtoolset-6 is dropped.