### PR TITLE
Disable weekly 39

### DIFF
--- a/jobs/weekly_release.groovy
+++ b/jobs/weekly_release.groovy
@@ -2,6 +2,7 @@ import util.Plumber
 
 def p = new Plumber(name: 'release/weekly-release', dsl: this)
 p.pipeline().with {
+  disabled()
   description('Tag and release the science-pipelines "weekly".')
 
   parameters {

--- a/jobs/weekly_release_cron.groovy
+++ b/jobs/weekly_release_cron.groovy
@@ -2,6 +2,7 @@ import util.Plumber
 
 def p = new Plumber(name: 'release/weekly-release-cron', dsl: this)
 p.pipeline().with {
+  disabled()
   description('Periodically trigger the DM pipelines/dax "weekly".')
 
   triggers {


### PR DESCRIPTION
Because of the outage, it is unclear how a weekly would be run this week.
I.e. when nodes will be rebooted etc.

For that reason, we will simply disable the weekly this week.