### PR TITLE
DM-55235: Remove DC2+Fakes jobs from Jenkins

### DIFF
--- a/etc/scipipe/ap_verify.yaml
+++ b/etc/scipipe/ap_verify.yaml
@@ -74,11 +74,3 @@ ap_verify:
       gen: 3
       code:
         <<: *code_ap
-    - dataset:
-        <<: *dataset_dc2
-        display_name: dc2+fakes
-        gen3_pipeline: >
-          ${AP_VERIFY_CI_DC2_DIR}/pipelines/ApVerifyWithFakes.yaml
-      gen: 3
-      code:
-        <<: *code_ap


### PR DESCRIPTION
Remove DC2 with fakes job from the scipipe matrix